### PR TITLE
add support for `application/json; charset=utf-8'

### DIFF
--- a/rest/request.go
+++ b/rest/request.go
@@ -29,7 +29,7 @@ type request struct {
 // decodePayload decodes the payload from the provided request
 func (r *request) decodePayload(payload *map[string]interface{}) *Error {
 	// Check content-type, if not specified, assume it's JSON and fail later
-	if ct := r.req.Header.Get("Content-Type"); ct != "" && ct != "application/json" {
+	if ct := r.req.Header.Get("Content-Type"); ct != "" && ct != "application/json" && ct != "application/json; charset=utf-8" {
 		return &Error{501, fmt.Sprintf("Invalid Content-Type header: `%s' not supported", ct), nil}
 	}
 	decoder := json.NewDecoder(r.req.Body)


### PR DESCRIPTION
$ lsb_release -a

No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 15.04
Release:	15.04
Codename:	vivid

$ http POST :8080/api/users name="John Doe"

HTTP/1.1 501 Not Implemented
Content-Length: 101
Content-Type: application/json
Date: Tue, 18 Aug 2015 12:24:21 GMT
Vary: Origin
{
    "code": 501, 
    "message": "Invalid Content-Type header: `application/json; charset=utf-8' not supported"
}

$ git apply /tmp/json_charset.diff

$ http POST :8080/api/users name="John Doe"

HTTP/1.1 201 Created
Content-Length: 138
Content-Location: /users/VdMkDF9nsgz5AAAB
Content-Type: application/json
Date: Tue, 18 Aug 2015 12:24:44 GMT
Etag: 7102dbc23398408cd2538fe8c4d261e1
Last-Modified: Tue, 18 Aug 2015 12:24:44 GMT
Vary: Origin
{
    "created": "2015-08-18T14:24:44.60879897+02:00", 
    "id": "VdMkDF9nsgz5AAAB", 
    "name": "John Doe", 
    "updated": "2015-08-18T14:24:44.608795076+02:00"
}