### PR TITLE
Update: standalone use case for Compile

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -52,7 +52,10 @@ func mergeFieldErrors(errs map[string][]interface{}, mergeErrs map[string][]inte
 	}
 }
 
-// Compile implements Compiler interface and call the same function on each field
+// Compile implements Compiler interface and call the same function on each field.
+// Note: if you use schema as a standalone library, it is the *caller's* responsibility
+// to invoke the Compile method before using Prepare or Validate on a Schema instance,
+// otherwise FieldValidator instances may not be initialized correctly.
 func (s Schema) Compile() error {
 	// Search for all Dependecy on fields, and compile then
 	if err := compileDependencies(s, s); err != nil {


### PR DESCRIPTION
When using rest-layer/schema as a standalone library, it is important
the caller of the schema.Schema instance invoke the Compile method
otherwise the hierarchy of FieldValidators will not be initialized
correctly. Usually this is done using the rest-layer framework
implicitly so is not normally a concern.