### PR TITLE
Initial JSONSchema Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The REST Layer framework is composed of several sub-packages:
 - [Custom Response Formatter / Sender](#custom-response-formatter-sender)
 - [GraphQL](#graphql)
 - [Hystrix](#hystrix)
+- [JSONSchema](#jsonschema)
 
 ## Features
 
@@ -72,6 +73,7 @@ The REST Layer framework is composed of several sub-packages:
 - [x] GraphQL query support
 - [ ] GraphQL mutation support
 - [ ] Swagger Documentation
+- [x] JSONSchema Output (partial)
 - [ ] Testing framework
 - [x] Sub resources
 - [ ] Cascading deletes on sub resources
@@ -693,7 +695,7 @@ Hooks are piece of code you can attach before or after an operation is performed
 | ---------------------- | -------------
 | [FindEventHandler]     | Defines a function called when the resource is listed with or without a query. Note that hook is called for both resource and item fetch as well a prior to updates and deletes.
 | [FoundEventHandler]    | Defines a function called with the result of a find on resource.
-| [GetEventHandler]      | Defines a function called when a get is performed on an item of the resource. Note: when multi-get is performed this hook is called for each items id individually. 
+| [GetEventHandler]      | Defines a function called when a get is performed on an item of the resource. Note: when multi-get is performed this hook is called for each items id individually.
 | [GotEventHandler]      | Defines a function called with the result of a get on a resource.
 | [InsertEventHandler]   | Defines a function called before an item is inserted.
 | [InsertedEventHandler] | Defines a function called after an item has been inserted.
@@ -719,7 +721,7 @@ Hooks are piece of code you can attach before or after an operation is performed
 
 All hooks functions get a `context.Context` as first argument. If a network call must be performed from the hook, the context's deadline must be respected. If a hook return an error, the whole request is aborted with that error.
 
-You can also use the context to pass data to your hooks from a middleware executed before REST Layer. This can be used to manage authentication for instance. See [examples/auth](https://github.com/rs/rest-layer/blob/master/examples/auth/main.go) to see an example. 
+You can also use the context to pass data to your hooks from a middleware executed before REST Layer. This can be used to manage authentication for instance. See [examples/auth](https://github.com/rs/rest-layer/blob/master/examples/auth/main.go) to see an example.
 
 ### Sub Resources
 
@@ -1404,6 +1406,40 @@ When wrapped this way, one Hystrix command is created per storage handler action
 Once enabled, you must configure Hystrix for each command and start the Hystrix metrics stream handler.
 
 See [Hystrix godoc](https://godoc.org/github.com/afex/hystrix-go/hystrix) for more info and [examples/hystrix](https://github.com/rs/rest-layer/blob/master/examples/hystrix/main.go) for a complete usage example with REST layer.
+
+## JSONSchema
+
+An incomplete but stil useful JSONSchema implementation that covers many common use cases for Schema. Goal is to try and match the draft-04 spec. Patches welcome.
+
+```go
+import "github.com/rs/rest-layer/schema/jsonschema"
+
+b := new(bytes.Buffer)
+enc := jsonschema.NewEncoder(b)
+if err := enc.Encode(myschema); err != nil {
+  return err
+}
+fmt.Println(b.String()) // Valid JSON Document describing the schema
+```
+
+### Supported FieldValidators
+
+ - [x] schema.Schema
+ - [x] schema.Bool
+ - [ ] schema.Null
+ - [x] schema.Float
+ - [x] schema.Integer
+ - [x] schema.String
+ - [x] schema.Time
+ - [ ] schema.URL
+ - [ ] schema.IP
+ - [ ] schema.Password
+ - [x] schema.Array
+ - [x] schema.Object
+ - [ ] schema.Dict
+ - [ ] schema.AllOf
+ - [ ] schema.AnyOf
+ - [ ] Custom validators
 
 ## Licenses
 

--- a/schema/encoding/jsonschema.go
+++ b/schema/encoding/jsonschema.go
@@ -1,0 +1,181 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/rs/rest-layer/schema"
+	"io"
+	"strconv"
+	"strings"
+)
+
+var (
+	// ErrNotImplemented means schema.FieldValidator type is not implemented
+	ErrNotImplemented = errors.New("Schema not Implemented")
+)
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew errWriter) writeFormat(format string, a ...interface{}) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, a...)
+}
+
+func (ew errWriter) writeString(s string) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = ew.w.Write([]byte(s))
+}
+
+func (ew errWriter) write(b []byte) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = ew.w.Write(b)
+}
+
+// ValidatorToJSONSchema takes a validator and renders to JSON
+func validatorToJSONSchema(w io.Writer, v schema.FieldValidator) (err error) {
+	if v == nil {
+		return nil
+	}
+	ew := errWriter{w: w}
+	switch t := v.(type) {
+	case *schema.String:
+		ew.writeString(`"type": "string"`)
+		if t.Regexp != "" {
+			ew.writeFormat(`, "pattern": %q`, t.Regexp)
+		}
+		if len(t.Allowed) > 0 {
+			var allowed []string
+			for _, value := range t.Allowed {
+				allowed = append(allowed, fmt.Sprintf("%q", value))
+			}
+			ew.writeFormat(`, "enum": [%s]`, strings.Join(allowed, ", "))
+		}
+		if t.MinLen > 0 {
+			ew.writeFormat(`, "minLength": %s`, strconv.FormatInt(int64(t.MinLen), 10))
+		}
+		if t.MaxLen > 0 {
+			ew.writeFormat(`, "maxLength": %s`, strconv.FormatInt(int64(t.MaxLen), 10))
+		}
+	case *schema.Integer:
+		ew.writeString(`"type": "integer"`)
+
+		if len(t.Allowed) > 0 {
+			var allowed []string
+			for _, value := range t.Allowed {
+				allowed = append(allowed, strconv.FormatInt(int64(value), 10))
+			}
+			ew.writeFormat(`, "enum": [%s]`, strings.Join(allowed, ","))
+		}
+		if t.Boundaries != nil {
+			ew.writeFormat(`, "minimum": %s, "maximum": %s`,
+				strconv.FormatFloat(t.Boundaries.Min, 'E', -1, 64),
+				strconv.FormatFloat(t.Boundaries.Max, 'E', -1, 64))
+		}
+	case *schema.Float:
+		ew.writeString(`"type": "number"`)
+		if len(t.Allowed) > 0 {
+			var allowed []string
+			for _, value := range t.Allowed {
+				allowed = append(allowed, strconv.FormatFloat(value, 'E', -1, 64))
+			}
+			ew.writeFormat(`, "enum": [%s]`, strings.Join(allowed, ","))
+		}
+		if t.Boundaries != nil {
+			ew.writeFormat(`, "minimum": %s, "maximum": %s`,
+				strconv.FormatFloat(t.Boundaries.Min, 'E', -1, 64),
+				strconv.FormatFloat(t.Boundaries.Max, 'E', -1, 64))
+		}
+
+	case *schema.Array:
+		ew.writeString(`"type": "array"`)
+		if t.ValuesValidator != nil {
+			ew.writeString(`, "items": `)
+			if ew.err == nil {
+				ew.err = validatorToJSONSchema(w, t.ValuesValidator)
+			}
+		}
+	case *schema.Object:
+		if ew.err == nil {
+			ew.err = schemaToJSONSchema(w, t.Schema)
+		}
+	case *schema.Time:
+		ew.writeString(`"type": "string", "format": "date-time"`)
+	case *schema.Bool:
+		ew.writeString(`"type": "boolean"`)
+	default:
+		return ErrNotImplemented
+	}
+	return ew.err
+}
+
+// SchemaToJSONSchema helper
+func schemaToJSONSchema(w io.Writer, s *schema.Schema) (err error) {
+	ew := errWriter{w: w}
+	ew.writeString("{")
+	if s.Description != "" {
+		ew.writeFormat(`"title": %q, `, s.Description)
+	}
+	ew.writeString(`"type": "object", `)
+	ew.writeString(`"properties": {`)
+	var required []string
+	var notFirst bool
+	for key, field := range s.Fields {
+		if notFirst {
+			ew.writeString(", ")
+		}
+		notFirst = true
+		ew.writeFormat("%q: {", key)
+		if field.Description != "" {
+			ew.writeFormat(`"description": %q, `, field.Description)
+		}
+		if field.Required {
+			required = append(required, fmt.Sprintf("%q", key))
+		}
+		if field.ReadOnly {
+			ew.writeFormat(`"readOnly": %t, `, field.ReadOnly)
+		}
+		if ew.err == nil {
+			ew.err = validatorToJSONSchema(w, field.Validator)
+		}
+		if field.Default != nil {
+			b, err := json.Marshal(field.Default)
+			if err != nil {
+				return err
+			}
+			ew.writeString(`, "default": `)
+			ew.write(b)
+		}
+		ew.writeString("}")
+		if ew.err != nil {
+			break
+		}
+	}
+	ew.writeFormat(`, "required": [%s]`, strings.Join(required, ", "))
+	ew.writeString("}}")
+	return ew.err
+}
+
+// Encoder encodes schema.Schema into a JSONSchema
+type Encoder struct {
+	io.Writer
+}
+
+// NewEncoder returns a new JSONSchema Encoder.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w}
+}
+
+// Encode is take schema and writes to Writer
+func (e *Encoder) Encode(s *schema.Schema) error {
+	return schemaToJSONSchema(e.Writer, s)
+}

--- a/schema/encoding/jsonschema_test.go
+++ b/schema/encoding/jsonschema_test.go
@@ -1,0 +1,351 @@
+package jsonschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/rs/rest-layer/schema"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func isValidJSON(payload []byte) (map[string]interface{}, error) {
+	b := bytes.NewBuffer(payload)
+	decoder := json.NewDecoder(b)
+	m := make(map[string]interface{})
+	err := decoder.Decode(&m)
+	return m, err
+}
+
+func copyStringToInterface(src []string) []interface{} {
+	dst := make([]interface{}, len(src))
+	for i, v := range src {
+		dst[i] = v
+	}
+	return dst
+}
+
+func TestReadOnlyField(t *testing.T) {
+	stringField := schema.Field{
+		ReadOnly:  true,
+		Validator: &schema.String{},
+	}
+	s := &schema.Schema{
+		Fields: schema.Fields{
+			"name": stringField,
+		},
+	}
+	b := new(bytes.Buffer)
+	jse := NewEncoder(b)
+	assert.NoError(t, jse.Encode(s))
+	_, err := isValidJSON(b.Bytes())
+	assert.NoError(t, err)
+	a := assert.New(t)
+	a.Contains(b.String(), `"readOnly": true`)
+	a.Contains(b.String(), `"name":`)
+	a.Contains(b.String(), `"type": "string"`)
+}
+
+func wrapWithJSONObject(b *bytes.Buffer) []byte {
+	return []byte(fmt.Sprintf("{%s}", b.String()))
+}
+
+func TestBoundaries(t *testing.T) {
+	validator := &schema.Integer{
+		Boundaries: &schema.Boundaries{Min: 10, Max: 100},
+	}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	m, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+	a := assert.New(t)
+	a.Equal(validator.Boundaries.Min, m["minimum"])
+	a.Equal(validator.Boundaries.Max, m["maximum"])
+}
+
+func TestRegexpEscaping(t *testing.T) {
+	validator := &schema.String{
+		Regexp: `\s+$`,
+	}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	_, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+	a := assert.New(t)
+	a.Contains(b.String(), string([]byte{'\\', '\\', 's', '+', '$'}))
+}
+
+func TestStringValidator(t *testing.T) {
+	validator := &schema.String{
+		MinLen: 3,
+		MaxLen: 23,
+	}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	m, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	// check string for values
+	a.Contains(strJSON, "minLength")
+	a.Contains(strJSON, "maxLength")
+	a.Contains(strJSON, `"type": "string"`)
+
+	// check decoded JSON for values
+	a.Equal("string", m["type"])
+	a.Equal(float64(validator.MinLen), m["minLength"])
+	a.Equal(float64(validator.MaxLen), m["maxLength"])
+
+}
+
+func TestEmptyStringValidator(t *testing.T) {
+	validator := &schema.String{}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	m, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	// check string for absence values
+	a.NotContains(strJSON, "minLength")
+	a.NotContains(strJSON, "maxLength")
+	// check string for values
+	a.Contains(strJSON, `"type": "string"`)
+
+	// check decoded JSON for values
+	a.Equal("string", m["type"])
+	_, ok := m["minLength"]
+	a.False(ok)
+	_, ok = m["maxLength"]
+	a.False(ok)
+}
+
+func TestAllowedStringValidation(t *testing.T) {
+	validator := &schema.String{
+		Allowed: []string{"one", "two"},
+	}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	m, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	a.NotContains(strJSON, "multipleOf")
+	a.Contains(strJSON, `"type": "string"`)
+	a.Contains(strJSON, `"enum"`)
+
+	a.Equal("string", m["type"])
+	assert.Len(t, m["enum"], 2)
+	a.Equal(copyStringToInterface([]string{"one", "two"}), m["enum"])
+}
+
+func TestIntegerValidatorNoBoundaryPanic(t *testing.T) {
+	validator := &schema.Integer{}
+	// Catch regressions in Integer boundary handling
+	assert.NotPanics(t, func() { validatorToJSONSchema(new(bytes.Buffer), validator) })
+}
+
+func TestStringValidatorNoBoundaryPanic(t *testing.T) {
+	validator := &schema.String{}
+	// Catch regressions in Integer boundary handling
+	assert.NotPanics(t, func() { validatorToJSONSchema(new(bytes.Buffer), validator) })
+}
+
+func TestAllowedIntegerValidator(t *testing.T) {
+	validator := &schema.Integer{
+		Allowed: []int{10, 50},
+	}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	m, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	a.Contains(strJSON, `"type": "integer"`)
+	a.Contains(strJSON, `"enum"`)
+
+	a.Equal("integer", m["type"])
+	assert.Len(t, m["enum"], 2)
+	values, ok := m["enum"].([]interface{})
+	a.True(ok)
+	a.Equal(float64(validator.Allowed[0]), values[0])
+	a.Equal(float64(validator.Allowed[1]), values[1])
+}
+
+func TestFloatValidator(t *testing.T) {
+	validator := &schema.Float{
+		Allowed: []float64{23.5, 98.6},
+	}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	m, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	a.Contains(strJSON, `"type": "number"`)
+	a.Contains(strJSON, `"enum"`)
+
+	a.Equal("number", m["type"])
+	assert.Len(t, m["enum"], 2)
+	values, ok := m["enum"].([]interface{})
+	a.True(ok)
+	a.Equal(validator.Allowed[0], values[0])
+	a.Equal(validator.Allowed[1], values[1])
+
+}
+
+func TestArray(t *testing.T) {
+	validator := &schema.Array{}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	_, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	a.Contains(strJSON, `"type": "array"`)
+}
+
+func TestTime(t *testing.T) {
+	validator := &schema.Time{}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	_, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	a.Contains(strJSON, `"type": "string"`)
+	a.Contains(strJSON, `"format": "date-time"`)
+}
+
+func TestBoolean(t *testing.T) {
+	validator := &schema.Bool{}
+	b := new(bytes.Buffer)
+	assert.NoError(t, validatorToJSONSchema(b, validator))
+	_, err := isValidJSON(wrapWithJSONObject(b))
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	strJSON := string(wrapWithJSONObject(b))
+	a.Contains(strJSON, `"type": "boolean"`)
+}
+
+func TestErrNotImplemented(t *testing.T) {
+	validator := &schema.IP{}
+	b := new(bytes.Buffer)
+	assert.Equal(t, ErrNotImplemented, validatorToJSONSchema(b, validator))
+}
+
+func TestArrayOfObjects(t *testing.T) {
+	s := &schema.Schema{
+		Description: "A list of students",
+		Fields: schema.Fields{
+			"students": schema.Field{
+				Validator: &schema.Array{
+					ValuesValidator: &schema.Object{
+						Schema: &schema.Schema{
+							Fields: schema.Fields{
+								"student": schema.Field{
+									Description: "a student",
+									Required:    true,
+									Default:     "Unknown",
+									Validator: &schema.String{
+										MinLen: 0,
+										MaxLen: 10,
+									},
+								},
+								"class": schema.Field{
+									Default: "Unassigned",
+									Validator: &schema.String{
+										MinLen: 0,
+										MaxLen: 10,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b := new(bytes.Buffer)
+	encoder := NewEncoder(b)
+	assert.NoError(t, encoder.Encode(s))
+
+	m, err := isValidJSON(b.Bytes())
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+	a.Equal("object", m["type"])
+	a.Equal("A list of students", m["title"])
+	p, ok := m["properties"].(map[string]interface{})
+	a.True(ok)
+	a.NotNil(p["students"])
+	students, ok := p["students"].(map[string]interface{})
+	a.True(ok)
+
+	a.Equal("array", students["type"])
+	items, ok := students["items"].(map[string]interface{})
+	a.True(ok)
+
+	a.Equal("object", items["type"])
+
+	ip, ok := items["properties"].(map[string]interface{})
+	a.True(ok)
+
+	a.Equal(copyStringToInterface([]string{"student"}), ip["required"])
+
+	student, ok := ip["student"].(map[string]interface{})
+	a.True(ok)
+	a.Equal("a student", student["description"])
+	a.Equal("Unknown", student["default"])
+
+	class, ok := ip["class"].(map[string]interface{})
+	a.True(ok)
+	a.Equal("Unassigned", class["default"])
+}
+
+func TestDefaultEncodingWithStringFieldAndIntegerDefault(t *testing.T) {
+	s := &schema.Schema{
+		Description: "thing",
+		Fields: schema.Fields{
+			"item": schema.Field{
+				Description: "an item",
+				Required:    true,
+				Default:     42, // deliberate ERROR we put an integer default on a string field!
+				Validator:   &schema.String{},
+			},
+		},
+	}
+	b := new(bytes.Buffer)
+	encoder := NewEncoder(b)
+	assert.NoError(t, encoder.Encode(s))
+
+	m, err := isValidJSON(b.Bytes())
+	assert.NoError(t, err)
+
+	a := assert.New(t)
+
+	p, ok := m["properties"].(map[string]interface{})
+	a.True(ok)
+	item, ok := p["item"].(map[string]interface{})
+	a.True(ok)
+
+	// Documenting the expected behavior, even though we know
+	// it's the potentially wrong. It should cause a run time error
+	// and therefore may not be usable in practice. This test
+	// confirms the behavior. Schema does not itself try to
+	// enforce any type safety on Default values and it is up to
+	// the developer
+
+	// It's allowed by the spec in section 6.2
+
+	a.Equal(float64(42), item["default"])
+}


### PR DESCRIPTION
About this PR:

- serve as a basis for discussion about whether this is something that
  should be part of schema
- resolve issues about efficiency and general approach
- discuss API naming
- serve as an initial implementation - this is incomplete but covers
  many common uses
- demonstrate some unit tests with the knowledge that the goconvey dependency needs
  to be removed
- doesn't generate errors - simply ignores elements it doesn't understand. I assume if something is valid Schema it should not have errors.

The API is extremely simple and returns a string as it's default output:

```
jsonSchema := jsonschema.SchemaToJSONSchema(&mySchema)
```

I use this as the output to a handler. By using a string I can embed it within other json documents, as it is itself valid JSON. It doesn't attempt to pretty print anything, just pass a valid well formed JSON document back to the caller.

As stated, it is an *incomplete* implementation, but it does work for a lot of common use cases and I think could be easily extended to cover many of the other use cases the JSONSchema spec encompasses. I have not tried to use this to generate code via a JSONSchema tool yet; but adding something like ```https://github.com/xeipuuv/gojsonschema``` as a unit test would be fairly easy.