### PR TITLE
Fix Object as a Field use case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
 - 1.6
+- 1.7
 - tip
 matrix:
   allow_failures:


### PR DESCRIPTION
I had not tested the object as a field use case thoroughly enough and
encountered this when I used it.

If you use Object as a Field of a Schema rather than as embedded in an
Array, it's original use case, the returned sub schema is wrapped in an
object. This creates invalid JSON.

 - modify the internal functions validatorToJSONSchema and
   schemaToJSONSchema to accept an object flag. If the flag is true then
   return the JSONSchema wrapped in an object. If false return it
   unwrapped.
 - the object flag to false when invoked from validatorToJSONSchema
 - the object flag is true when invoked from schema.Array handler
 - this also guards against nil in the schema.Object Schema field
 - cover array case with nil schema