### PR TITLE
Add additional properties key

### DIFF
--- a/schema/encoding/jsonschema/jsonschema.go
+++ b/schema/encoding/jsonschema/jsonschema.go
@@ -133,6 +133,7 @@ func schemaToJSONSchema(w io.Writer, s *schema.Schema) (err error) {
 		ew.writeFormat(`"title": %q, `, s.Description)
 	}
 	ew.writeString(`"type": "object", `)
+	ew.writeString(`"additionalProperties": false, `)
 	ew.writeString(`"properties": {`)
 	var required []string
 	var notFirst bool

--- a/schema/encoding/jsonschema/jsonschema_test.go
+++ b/schema/encoding/jsonschema/jsonschema_test.go
@@ -417,11 +417,13 @@ func TestArrayOfObjects(t *testing.T) {
 	const expect = `{
 		"type": "object",
 		"title": "A list of students",
+		"additionalProperties": false,
 		"properties": {
 			"students": {
 				"type": "array",
 				"items": {
 					"type": "object",
+					"additionalProperties": false,
 					"properties": {
 						"student": {
 							"type": "string",


### PR DESCRIPTION
 Schema has a strict interpretation of the schema, and is explicit about
 what it accepts. A conforming JSONSchema document should set
 "additionalProperties" to false to document this behavior.

 This documents the existing behavior of schema, which is do not accept
 parameters which have not been specified.

 @see http://json-schema.org/latest/json-schema-validation.html#anchor64