### PR TITLE
Issue #50 detect invalid fields

### DIFF
--- a/schema/encoding/jsonschema/all_test.go
+++ b/schema/encoding/jsonschema/all_test.go
@@ -370,6 +370,25 @@ func TestEncoder(t *testing.T) {
 				}
 			}`,
 		},
+		{
+			name: `Incorrectly configured field`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"location": schema.Field{
+						Description: "location of your stuff",
+					},
+				},
+			},
+			expect: `{
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"location": {
+						"description": "location of your stuff"
+					}
+				}
+			}`,
+		},
 	}
 	for i := range testCases {
 		testCases[i].Run(t)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -323,6 +323,9 @@ func (s Schema) validate(changes map[string]interface{}, base map[string]interfa
 				doc[field] = value
 			}
 		}
+		if def.Schema == nil && def.Validator == nil {
+			addFieldError(errs, field, fmt.Errorf("At least one of Validator or Schema should be set."))
+		}
 	}
 	return doc, errs
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,23 @@
+package schema
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestForIncorrectlyConstructedField(t *testing.T) {
+	s := Schema{
+		Fields: Fields{
+			"name": Field{},
+		},
+	}
+
+	changes := make(map[string]interface{})
+	base := make(map[string]interface{})
+	base["name"] = "Fred"
+	_, errs := s.Validate(changes, base)
+	assert.Len(t, errs, 1, "should contain an error")
+	err, ok := errs["name"][0].(error)
+	assert.True(t, ok, "name field has not been set as an error")
+	assert.Equal(t, err.Error(), "At least one of Validator or Schema should be set.")
+}


### PR DESCRIPTION
1st commit updates schema to detect condition where both the Validator and the Schema haven't been set and return an error.

2nd commit fixes up the Encoder so that it is more robust when emitting field properties.