### PR TITLE
Issue #50 fix up JSONSchema to not emit invalid JSON

### DIFF
--- a/schema/encoding/jsonschema/all_test.go
+++ b/schema/encoding/jsonschema/all_test.go
@@ -370,6 +370,25 @@ func TestEncoder(t *testing.T) {
 				}
 			}`,
 		},
+		{
+			name: `Incorrectly configured field`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"location": schema.Field{
+						Description: "location of your stuff",
+					},
+				},
+			},
+			expect: `{
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"location": {
+						"description": "location of your stuff"
+					}
+				}
+			}`,
+		},
 	}
 	for i := range testCases {
 		testCases[i].Run(t)

--- a/schema/encoding/jsonschema/jsonschema.go
+++ b/schema/encoding/jsonschema/jsonschema.go
@@ -27,20 +27,21 @@ type errWriter struct {
 	properties int       // track properties written
 }
 
-// Comma optionally outputs a comma.
+// comma optionally outputs a comma.
 // Invoke this when you're about to write a property.
 // Tracks how many have been written and emits if not the first.
-func (ew *errWriter) Comma() {
+func (ew *errWriter) comma() {
 	if ew.properties > 0 {
 		ew.writeString(",")
 	}
 	ew.properties++
 }
 
-func (ew *errWriter) ResetPropertiesCount() {
+func (ew *errWriter) resetPropertiesCount() {
 	ew.properties = 0
 }
 
+// Compatibility with io.Writer interface
 func (ew errWriter) Write(p []byte) (int, error) {
 	if ew.err != nil {
 		return 0, ew.err
@@ -62,7 +63,7 @@ func (ew errWriter) writeString(s string) {
 	_, ew.err = ew.w.Write([]byte(s))
 }
 
-func (ew errWriter) write(b []byte) {
+func (ew errWriter) writeBytes(b []byte) {
 	if ew.err != nil {
 		return
 	}
@@ -163,15 +164,15 @@ func validatorToJSONSchema(w io.Writer, v schema.FieldValidator) (err error) {
 func serializeField(ew errWriter, key string, field schema.Field) error {
 	ew.writeFormat("%q: {", key)
 	if field.Description != "" {
-		ew.Comma()
+		ew.comma()
 		ew.writeFormat(`"description": %q`, field.Description)
 	}
 	if field.ReadOnly {
-		ew.Comma()
+		ew.comma()
 		ew.writeFormat(`"readOnly": %t`, field.ReadOnly)
 	}
 	if field.Validator != nil {
-		ew.Comma()
+		ew.comma()
 		ew.err = validatorToJSONSchema(ew, field.Validator)
 	}
 	if field.Default != nil {
@@ -179,12 +180,12 @@ func serializeField(ew errWriter, key string, field schema.Field) error {
 		if err != nil {
 			return err
 		}
-		ew.Comma()
+		ew.comma()
 		ew.writeString(`"default": `)
-		ew.write(b)
+		ew.writeBytes(b)
 	}
 	ew.writeString("}")
-	ew.ResetPropertiesCount()
+	ew.resetPropertiesCount()
 	return nil
 }
 


### PR DESCRIPTION
Fixes up the Encoder so that it is more robust when emitting field properties.

I tried patching schema to detect nil Validator and Schema but this broke a lot of unit tests so I'm withdrawing that part of the patch.

@smyrman @rs this probably needs some review, but it does pass the tests inside of schema. Having problems running the tests involving MemoryHandler

```
rest/method_item_delete_test.go:23: cannot use s (type *mem.MemoryHandler) as type resource.Storer in argument to index.Bind:
        *mem.MemoryHandler does not implement resource.Storer (wrong type for Clear method)
                have Clear("golang.org/x/net/context".Context, *resource.Lookup) (int, error)
                want Clear("context".Context, *resource.Lookup) (int, error)
```

I probably have an old version in my GOPATH.