### PR TITLE
Issue #52: Adding MaxLen/MinLen to schema.Array

### DIFF
--- a/schema/all_test.go
+++ b/schema/all_test.go
@@ -1,0 +1,51 @@
+// +build go1.7
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/rs/rest-layer/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+type compilerTestCase struct {
+	Name     string
+	Compiler schema.Compiler
+	Error    string
+}
+
+func (tc compilerTestCase) Run(t *testing.T) {
+	t.Run(tc.Name, func(t *testing.T) {
+		t.Parallel()
+
+		err := tc.Compiler.Compile()
+		if tc.Error == "" {
+			assert.NoError(t, err)
+		} else {
+			assert.EqualError(t, err, tc.Error)
+		}
+	})
+}
+
+type fieldValidatorTestCase struct {
+	Name          string
+	Validator     schema.FieldValidator
+	Input, Expect interface{}
+	Error         string
+}
+
+func (tc fieldValidatorTestCase) Run(t *testing.T) {
+	t.Run(tc.Name, func(t *testing.T) {
+		t.Parallel()
+
+		v, err := tc.Validator.Validate(tc.Input)
+		if tc.Error == "" {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Expect, v)
+		} else {
+			assert.EqualError(t, err, tc.Error)
+			assert.Nil(t, v)
+		}
+	})
+}

--- a/schema/array.go
+++ b/schema/array.go
@@ -9,6 +9,10 @@ import (
 type Array struct {
 	// ValuesValidator is the validator to apply on array items
 	ValuesValidator FieldValidator
+	// MinLen defines the minimum array length (default 0)
+	MinLen int
+	// MaxLen defines the maximum array length (default no limit)
+	MaxLen int
 }
 
 // Compile implements Compiler interface
@@ -35,6 +39,13 @@ func (v Array) Validate(value interface{}) (interface{}, error) {
 			}
 			arr[i] = val
 		}
+	}
+	l := len(arr)
+	if l < v.MinLen {
+		return nil, fmt.Errorf("has fewer items than %d", v.MinLen)
+	}
+	if v.MaxLen > 0 && l > v.MaxLen {
+		return nil, fmt.Errorf("has more items than %d", v.MaxLen)
 	}
 	return arr, nil
 }

--- a/schema/array_test.go
+++ b/schema/array_test.go
@@ -1,29 +1,82 @@
-package schema
+// +build go1.7
+
+package schema_test
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/rs/rest-layer/schema"
 )
 
 func TestArrayValidatorCompile(t *testing.T) {
-	v := &Array{ValuesValidator: &String{}}
-	err := v.Compile()
-	assert.NoError(t, err)
-	v = &Array{ValuesValidator: &String{Regexp: "[invalid re"}}
-	err = v.Compile()
-	assert.EqualError(t, err, "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`")
-
+	testCases := []compilerTestCase{
+		{
+			Name:     "ValuesValidator=&String{}",
+			Compiler: &schema.Array{ValuesValidator: &schema.String{}},
+		},
+		{
+			Name:     "ValuesValidator=&String{Regexp:invalid}",
+			Compiler: &schema.Array{ValuesValidator: &schema.String{Regexp: "[invalid re"}},
+			Error:    "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`",
+		},
+	}
+	for i := range testCases {
+		testCases[i].Run(t)
+	}
 }
 
 func TestArrayValidator(t *testing.T) {
-	v, err := Array{ValuesValidator: &Bool{}}.Validate([]interface{}{true, false})
-	assert.NoError(t, err)
-	assert.Equal(t, []interface{}{true, false}, v)
-	v, err = Array{ValuesValidator: &Bool{}}.Validate([]interface{}{true, "value"})
-	assert.EqualError(t, err, "invalid value at #2: not a Boolean")
-	assert.Equal(t, nil, v)
-	v, err = Array{ValuesValidator: &String{}}.Validate("value")
-	assert.EqualError(t, err, "not an array")
-	assert.Equal(t, nil, v)
+	testCases := []fieldValidatorTestCase{
+		{
+			Name:      `ValuesValidator=nil,Validate([]interface{}{true,"value"})`,
+			Validator: &schema.Array{},
+			Input:     []interface{}{true, "value"},
+			Expect:    []interface{}{true, "value"},
+		},
+		{
+			Name:      `ValuesValidator=&schema.Bool{},Validate([]interface{}{true,false})`,
+			Validator: &schema.Array{ValuesValidator: &schema.Bool{}},
+			Input:     []interface{}{true, false},
+			Expect:    []interface{}{true, false},
+		},
+		{
+			Name:      `ValuesValidator=&schema.Bool{},Validate([]interface{}{true,"value"})`,
+			Validator: &schema.Array{ValuesValidator: &schema.Bool{}},
+			Input:     []interface{}{true, "value"},
+			Error:     "invalid value at #2: not a Boolean",
+		},
+		{
+			Name:      `ValuesValidator=&String{},Validate("value")`,
+			Validator: &schema.Array{ValuesValidator: &schema.String{}},
+			Input:     "value",
+			Error:     "not an array",
+		},
+		{
+			Name:      `MinLen=2,Validate([]interface{}{true,false})`,
+			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MinLen: 2},
+			Input:     []interface{}{true, false},
+			Expect:    []interface{}{true, false},
+		},
+		{
+			Name:      `MinLen=3,Validate([]interface{}{true,false})`,
+			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MinLen: 3},
+			Input:     []interface{}{true, false},
+			Error:     "has fewer items than 3",
+		},
+		{
+			Name:      `MaxLen=2,Validate([]interface{}{true,false})`,
+			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MaxLen: 2},
+			Input:     []interface{}{true, false},
+			Expect:    []interface{}{true, false},
+		},
+		{
+			Name:      `MaxLen=1,Validate([]interface{}{true,false})`,
+			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MaxLen: 1},
+			Input:     []interface{}{true, false},
+			Error:     "has more items than 1",
+		},
+	}
+	for i := range testCases {
+		testCases[i].Run(t)
+	}
 }

--- a/schema/encoding/jsonschema/array_test.go
+++ b/schema/encoding/jsonschema/array_test.go
@@ -1,0 +1,61 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/rs/rest-layer/schema"
+)
+
+func TestArray(t *testing.T) {
+	testCases := []encoderTestCase{
+		{
+			name: "ValuesValidator=nil",
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"a": schema.Field{
+						Validator: &schema.Array{},
+					},
+				},
+			},
+			customValidate: fieldValidator("a", `{"type": "array"}`),
+		},
+		{
+			name: "ValuesValidator=&schema.Bool{}",
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"a": schema.Field{
+						Validator: &schema.Array{ValuesValidator: &schema.Bool{}},
+					},
+				},
+			},
+			customValidate: fieldValidator("a", `{"type": "array", "items": {"type": "boolean"}}`),
+		},
+		{
+			// http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.11
+			name: "MinLen=42",
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"a": schema.Field{
+						Validator: &schema.Array{MinLen: 42},
+					},
+				},
+			},
+			customValidate: fieldValidator("a", `{"type": "array", "minItems": 42}`),
+		},
+		{
+			// http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.10
+			name: "MaxLen=42",
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"a": schema.Field{
+						Validator: &schema.Array{MaxLen: 42},
+					},
+				},
+			},
+			customValidate: fieldValidator("a", `{"type": "array", "maxItems": 42}`),
+		},
+	}
+	for i := range testCases {
+		testCases[i].Run(t)
+	}
+}

--- a/schema/encoding/jsonschema/jsonschema.go
+++ b/schema/encoding/jsonschema/jsonschema.go
@@ -144,6 +144,12 @@ func validatorToJSONSchema(w io.Writer, v schema.FieldValidator) (err error) {
 		}
 	case *schema.Array:
 		ew.writeString(`"type": "array"`)
+		if t.MinLen > 0 {
+			ew.writeFormat(`, "minItems": %s`, strconv.FormatInt(int64(t.MinLen), 10))
+		}
+		if t.MaxLen > 0 {
+			ew.writeFormat(`, "maxItems": %s`, strconv.FormatInt(int64(t.MaxLen), 10))
+		}
 		if t.ValuesValidator != nil {
 			ew.writeString(`, "items": {`)
 			if ew.err == nil {

--- a/schema/encoding/jsonschema/jsonschema_test.go
+++ b/schema/encoding/jsonschema/jsonschema_test.go
@@ -65,18 +65,6 @@ func TestFloatValidator(t *testing.T) {
 
 }
 
-func TestArray(t *testing.T) {
-	validator := &schema.Array{}
-	b := new(bytes.Buffer)
-	assert.NoError(t, validatorToJSONSchema(b, validator))
-	_, err := isValidJSON(wrapWithJSONObject(b))
-	assert.NoError(t, err)
-
-	a := assert.New(t)
-	strJSON := string(wrapWithJSONObject(b))
-	a.Contains(strJSON, `"type": "array"`)
-}
-
 func TestTime(t *testing.T) {
 	validator := &schema.Time{}
 	b := new(bytes.Buffer)


### PR DESCRIPTION
This adds MaxLen/MinLen parameters to schema.Array, and updates
the jsonschema package to also handle these new parameters.

Array tests has been converted to table-tests for both packages.
For the schema package, the tests are now Go 1.7 only.