### PR TITLE
Issue #52: Adding MinLen/MaxLen to Dict and Schema

### DIFF
--- a/schema/dict.go
+++ b/schema/dict.go
@@ -11,6 +11,10 @@ type Dict struct {
 	KeysValidator FieldValidator
 	// ValuesValidator is the validator to apply on dict values
 	ValuesValidator FieldValidator
+	// MinLen defines the minimum number of fields (default 0)
+	MinLen int
+	// MaxLen defines the maximum number of fields (default no limit)
+	MaxLen int
 }
 
 // Compile implements Compiler interface
@@ -53,6 +57,13 @@ func (v Dict) Validate(value interface{}) (interface{}, error) {
 			}
 		}
 		dest[key] = val
+	}
+	l := len(dest)
+	if l < v.MinLen {
+		return nil, fmt.Errorf("has fewer properties than %d", v.MinLen)
+	}
+	if v.MaxLen > 0 && l > v.MaxLen {
+		return nil, fmt.Errorf("has more properties than %d", v.MaxLen)
 	}
 	return dest, nil
 }

--- a/schema/dict_test.go
+++ b/schema/dict_test.go
@@ -1,45 +1,102 @@
-package schema
+// +build go1.7
+
+package schema_test
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/rs/rest-layer/schema"
 )
 
 func TestDictValidatorCompile(t *testing.T) {
-	v := &Dict{KeysValidator: &String{}, ValuesValidator: &String{}}
-	err := v.Compile()
-	assert.NoError(t, err)
-	v = &Dict{
-		KeysValidator: &String{Regexp: "[invalid re"},
+	testCases := []compilerTestCase{
+		{
+			Name: "KeysValidator=&String{},ValuesValidator=&String{}",
+			Compiler: &schema.Dict{
+				KeysValidator:   &schema.String{},
+				ValuesValidator: &schema.String{},
+			},
+		},
+		{
+			Name:     "KeysValidator=&String{Regexp:invalid}",
+			Compiler: &schema.Dict{KeysValidator: &schema.String{Regexp: "[invalid re"}},
+			Error:    "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`",
+		},
+		{
+			Name:     "ValuesValidator=&String{Regexp:invalid}",
+			Compiler: &schema.Dict{ValuesValidator: &schema.String{Regexp: "[invalid re"}},
+			Error:    "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`",
+		},
 	}
-	err = v.Compile()
-	assert.EqualError(t, err, "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`")
-	v = &Dict{
-		ValuesValidator: &String{Regexp: "[invalid re"},
+	for i := range testCases {
+		testCases[i].Run(t)
 	}
-	err = v.Compile()
-	assert.EqualError(t, err, "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`")
 }
 
 func TestDictValidator(t *testing.T) {
-	v, err := Dict{KeysValidator: &String{}}.Validate(map[string]interface{}{"foo": true, "bar": false})
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{"foo": true, "bar": false}, v)
-	v, err = Dict{KeysValidator: &String{MinLen: 3}}.Validate(map[string]interface{}{"foo": true, "ba": false})
-	assert.EqualError(t, err, "invalid key `ba': is shorter than 3")
-	assert.Equal(t, nil, v)
-	v, err = Dict{ValuesValidator: &Bool{}}.Validate(map[string]interface{}{"foo": true, "bar": false})
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{"foo": true, "bar": false}, v)
-	v, err = Dict{ValuesValidator: &Bool{}}.Validate(map[string]interface{}{"foo": true, "bar": "value"})
-	assert.EqualError(t, err, "invalid value for key `bar': not a Boolean")
-	assert.Equal(t, nil, v)
-	v, err = Dict{ValuesValidator: &String{}}.Validate("value")
-	assert.EqualError(t, err, "not a dict")
-	assert.Equal(t, nil, v)
-	v, err = Dict{ValuesValidator: &String{}}.Validate([]interface{}{"value"})
-	assert.EqualError(t, err, "not a dict")
-	assert.Equal(t, nil, v)
-
+	testCases := []fieldValidatorTestCase{
+		{
+			Name:      `KeysValidator=&String{},Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Validator: &schema.Dict{KeysValidator: &schema.String{}},
+			Input:     map[string]interface{}{"foo": true, "bar": false},
+			Expect:    map[string]interface{}{"foo": true, "bar": false},
+		},
+		{
+			Name:      `KeysValidator=&String{MinLen:3},Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Validator: &schema.Dict{KeysValidator: &schema.String{MinLen: 3}},
+			Input:     map[string]interface{}{"foo": true, "bar": false},
+			Expect:    map[string]interface{}{"foo": true, "bar": false},
+		},
+		{
+			Name:      `KeysValidator=&String{MinLen:3},Validate(map[string]interface{}{"foo":true,"ba":false})`,
+			Validator: &schema.Dict{KeysValidator: &schema.String{MinLen: 3}},
+			Input:     map[string]interface{}{"foo": true, "ba": false},
+			Error:     "invalid key `ba': is shorter than 3",
+		},
+		{
+			Name:      `ValuesValidator=&Bool{},Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Validator: &schema.Dict{ValuesValidator: &schema.Bool{}},
+			Input:     map[string]interface{}{"foo": true, "bar": false},
+			Expect:    map[string]interface{}{"foo": true, "bar": false},
+		},
+		{
+			Name:      `ValuesValidator=&Bool{},Validate(map[string]interface{}{"foo":true,"bar":"value"})`,
+			Validator: &schema.Dict{ValuesValidator: &schema.Bool{}},
+			Input:     map[string]interface{}{"foo": true, "bar": "value"},
+			Error:     "invalid value for key `bar': not a Boolean",
+		},
+		{
+			Name:      `ValuesValidator=&String{},Validate("value")`,
+			Validator: &schema.Dict{ValuesValidator: &schema.String{}},
+			Input:     "value",
+			Error:     "not a dict",
+		},
+		{
+			Name:      `MinLen=2,Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Validator: &schema.Dict{MinLen: 2},
+			Input:     map[string]interface{}{"foo": true, "bar": "value"},
+			Expect:    map[string]interface{}{"foo": true, "bar": "value"},
+		},
+		{
+			Name:      `MinLen=3,Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Validator: &schema.Dict{MinLen: 3},
+			Input:     map[string]interface{}{"foo": true, "bar": "value"},
+			Error:     "has fewer properties than 3",
+		},
+		{
+			Name:      `MaxLen=2,Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Validator: &schema.Dict{MaxLen: 3},
+			Input:     map[string]interface{}{"foo": true, "bar": "value"},
+			Expect:    map[string]interface{}{"foo": true, "bar": "value"},
+		},
+		{
+			Name:      `MaxLen=1,Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Validator: &schema.Dict{MaxLen: 1},
+			Input:     map[string]interface{}{"foo": true, "bar": "value"},
+			Error:     "has more properties than 1",
+		},
+	}
+	for i := range testCases {
+		testCases[i].Run(t)
+	}
 }

--- a/schema/encoding/jsonschema/all_test.go
+++ b/schema/encoding/jsonschema/all_test.go
@@ -175,7 +175,61 @@ func TestEncoder(t *testing.T) {
 			}`,
 		},
 		{
-			name: "Required=true(1/1)",
+			name: "MinLen=2",
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"foo": schema.Field{
+						Validator: &schema.Bool{},
+					},
+					"bar": schema.Field{
+						Validator: &schema.Bool{},
+					},
+					"baz": schema.Field{
+						Validator: &schema.Bool{},
+					},
+				},
+				MinLen: 2,
+			},
+			expect: `{
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"foo": {"type": "boolean"},
+					"bar": {"type": "boolean"},
+					"baz": {"type": "boolean"}
+				},
+				"minProperties": 2
+			}`,
+		},
+		{
+			name: "MaxLen=2",
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"foo": schema.Field{
+						Validator: &schema.Bool{},
+					},
+					"bar": schema.Field{
+						Validator: &schema.Bool{},
+					},
+					"baz": schema.Field{
+						Validator: &schema.Bool{},
+					},
+				},
+				MaxLen: 2,
+			},
+			expect: `{
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"foo": {"type": "boolean"},
+					"bar": {"type": "boolean"},
+					"baz": {"type": "boolean"}
+				},
+				"maxProperties": 2
+			}`,
+		},
+		{
+			name: "Required=true(1/2)",
 			schema: schema.Schema{
 				Fields: schema.Fields{
 					"name": schema.Field{

--- a/schema/encoding/jsonschema/jsonschema.go
+++ b/schema/encoding/jsonschema/jsonschema.go
@@ -229,6 +229,12 @@ func schemaToJSONSchema(w io.Writer, s *schema.Schema) (err error) {
 		}
 	}
 	ew.writeString("}")
+	if s.MinLen > 0 {
+		ew.writeFormat(`, "minProperties": %s`, strconv.FormatInt(int64(s.MinLen), 10))
+	}
+	if s.MaxLen > 0 {
+		ew.writeFormat(`, "maxProperties": %s`, strconv.FormatInt(int64(s.MaxLen), 10))
+	}
 
 	if len(required) > 0 {
 		ew.writeFormat(`, "required": [%s]`, strings.Join(required, ", "))

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -14,6 +14,10 @@ type Schema struct {
 	Description string
 	// Fields defines the schema's allowed fields
 	Fields Fields
+	// MinLen defines the minimum number of fields (default 0)
+	MinLen int
+	// MaxLen defines the maximum number of fields (default no limit)
+	MaxLen int
 }
 
 // Validator is an interface used to validate schema against actual data
@@ -323,6 +327,15 @@ func (s Schema) validate(changes map[string]interface{}, base map[string]interfa
 				doc[field] = value
 			}
 		}
+	}
+	l := len(doc)
+	if l < s.MinLen {
+		addFieldError(errs, "", fmt.Sprintf("has fewer properties than %d", s.MinLen))
+		return nil, errs
+	}
+	if s.MaxLen > 0 && l > s.MaxLen {
+		addFieldError(errs, "", fmt.Sprintf("has more properties than %d", s.MaxLen))
+		return nil, errs
 	}
 	return doc, errs
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,90 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/rs/rest-layer/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemaValidator(t *testing.T) {
+	minLenSchema := &schema.Schema{
+		Fields: schema.Fields{
+			"foo": schema.Field{
+				Validator: &schema.Bool{},
+			},
+			"bar": schema.Field{
+				Validator: &schema.Bool{},
+			},
+			"baz": schema.Field{
+				Validator: &schema.Bool{},
+			},
+		},
+		MinLen: 2,
+	}
+	assert.NoError(t, minLenSchema.Compile())
+
+	maxLenSchema := &schema.Schema{
+		Fields: schema.Fields{
+			"foo": schema.Field{
+				Validator: &schema.Bool{},
+			},
+			"bar": schema.Field{
+				Validator: &schema.Bool{},
+			},
+			"baz": schema.Field{
+				Validator: &schema.Bool{},
+			},
+		},
+		MaxLen: 2,
+	}
+	assert.NoError(t, maxLenSchema.Compile())
+
+	testCases := []struct {
+		Name                 string
+		Schema               *schema.Schema
+		Base, Change, Expect map[string]interface{}
+		Errors               map[string][]interface{}
+	}{
+		{
+			Name:   `MinLen=2,Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Schema: minLenSchema,
+			Change: map[string]interface{}{"foo": true, "bar": false},
+			Expect: map[string]interface{}{"foo": true, "bar": false},
+		},
+		{
+			Name:   `MinLen=2,Validate(map[string]interface{}{"foo":true})`,
+			Schema: minLenSchema,
+			Change: map[string]interface{}{"foo": true},
+			Errors: map[string][]interface{}{"": []interface{}{"has fewer properties than 2"}},
+		},
+		{
+			Name:   `MaxLen=2,Validate(map[string]interface{}{"foo":true,"bar":false})`,
+			Schema: maxLenSchema,
+			Change: map[string]interface{}{"foo": true, "bar": false},
+			Expect: map[string]interface{}{"foo": true, "bar": false},
+		},
+		{
+			Name:   `MaxLen=2,Validate(map[string]interface{}{"foo":true,"bar":true,"baz":false})`,
+			Schema: maxLenSchema,
+			Change: map[string]interface{}{"foo": true, "bar": true, "baz": false},
+			Errors: map[string][]interface{}{"": []interface{}{"has more properties than 2"}},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			doc, errs := tc.Schema.Validate(tc.Base, tc.Change)
+			if len(tc.Errors) == 0 {
+				assert.Len(t, errs, 0)
+				assert.Equal(t, tc.Expect, doc)
+			} else {
+				assert.Equal(t, tc.Errors, errs)
+				assert.Nil(t, doc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Dict and Schema now got MinLen/MaxLen in the same way as Array. For
Schema only, the JSON Schema encoding has been updated to include
minProperties/maxProperties based on these values. Dict is not yet
supported.

Dict tests have been rewritten to table-tests, while Schema has
received new table-tests in both packages.