### PR TITLE
jsonschema: Encoder benchmarks

### DIFF
--- a/schema/encoding/jsonschema/all_test.go
+++ b/schema/encoding/jsonschema/all_test.go
@@ -12,6 +12,76 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// studentSchema serves as a complex nested schema example.
+var studentSchema = schema.Schema{
+	Description: "Object with array of students",
+	Fields: schema.Fields{
+		"students": {
+			Description: "Array of students",
+			Validator: &schema.Array{
+				ValuesValidator: &schema.Object{
+					Schema: &schema.Schema{
+						Description: "Student and class",
+						Fields: schema.Fields{
+							"student": {
+								Description: "The student name",
+								Required:    true,
+								Default:     "Unknown",
+								Validator: &schema.String{
+									MinLen: 1,
+									MaxLen: 10,
+								},
+							},
+							"class": {
+								Description: "The class name",
+								Default:     "Unassigned",
+								Validator: &schema.String{
+									MinLen: 0, // Default value.
+									MaxLen: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// studentSchemaJSON contains the expected JSON serialization of studentSchema.
+const studentSchemaJSON = `{
+	"type": "object",
+	"description": "Object with array of students",
+	"additionalProperties": false,
+	"properties": {
+		"students": {
+			"type": "array",
+			"description": "Array of students",
+			"items": {
+				"type": "object",
+				"description": "Student and class",
+				"additionalProperties": false,
+				"properties": {
+					"student": {
+						"type": "string",
+						"description": "The student name",
+						"default": "Unknown",
+						"minLength": 1,
+						"maxLength": 10
+					},
+					"class": {
+						"type": "string",
+						"description": "The class name",
+						"default": "Unassigned",
+						"maxLength": 10
+					}
+				},
+				"required": ["student"]
+			}
+		}
+	}
+}`
+
 type dummyValidator struct{}
 
 func (v dummyValidator) Validate(value interface{}) (interface{}, error) {
@@ -340,73 +410,9 @@ func TestEncoder(t *testing.T) {
 			}`,
 		},
 		{
-			name: "Validator=Array,ValuesValidator=Object{Schema:Student}",
-			schema: schema.Schema{
-				Description: "Object with array of students",
-				Fields: schema.Fields{
-					"students": {
-						Description: "Array of students",
-						Validator: &schema.Array{
-							ValuesValidator: &schema.Object{
-								Schema: &schema.Schema{
-									Description: "Student and class",
-									Fields: schema.Fields{
-										"student": {
-											Description: "The student name",
-											Required:    true,
-											Default:     "Unknown",
-											Validator: &schema.String{
-												MinLen: 1,
-												MaxLen: 10,
-											},
-										},
-										"class": {
-											Description: "The class name",
-											Default:     "Unassigned",
-											Validator: &schema.String{
-												MinLen: 0, // Default value.
-												MaxLen: 10,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expect: `{
-				"type": "object",
-				"description": "Object with array of students",
-				"additionalProperties": false,
-				"properties": {
-					"students": {
-						"type": "array",
-						"description": "Array of students",
-						"items": {
-							"type": "object",
-							"description": "Student and class",
-							"additionalProperties": false,
-							"properties": {
-								"student": {
-									"type": "string",
-									"description": "The student name",
-									"default": "Unknown",
-									"minLength": 1,
-									"maxLength": 10
-								},
-								"class": {
-									"type": "string",
-									"description": "The class name",
-									"default": "Unassigned",
-									"maxLength": 10
-								}
-							},
-							"required": ["student"]
-						}
-					}
-				}
-			}`,
+			name:   "Validator=Array,ValuesValidator=Object{Schema:Student}",
+			schema: studentSchema,
+			expect: studentSchemaJSON,
 		},
 		{
 			name: `Validator=Object,Fields["location"].Validator=Object`,

--- a/schema/encoding/jsonschema/benchmark_test.go
+++ b/schema/encoding/jsonschema/benchmark_test.go
@@ -1,0 +1,54 @@
+package jsonschema_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/rest-layer/schema"
+	"github.com/rs/rest-layer/schema/encoding/jsonschema"
+)
+
+func BenchmarkEncoder(b *testing.B) {
+	testCases := []struct {
+		Name   string
+		Schema schema.Schema
+	}{
+		{
+			Name: `Schema={Fields:{"b":Bool{}}}`,
+			Schema: schema.Schema{
+				Fields: schema.Fields{
+					"b": {Validator: &schema.Bool{}},
+				},
+			},
+		},
+		{
+			Name: `Schema={Fields:{"s":String{}}}`,
+			Schema: schema.Schema{
+				Fields: schema.Fields{
+					"s": {Validator: &schema.String{}},
+				},
+			},
+		},
+		{
+			Name: `Schema={Fields:{"s":String{MaxLen:42}}}`,
+			Schema: schema.Schema{
+				Fields: schema.Fields{
+					"s": {Validator: &schema.String{MaxLen: 42}},
+				},
+			},
+		},
+		{
+			Name:   `Schema=Student`,
+			Schema: studentSchema,
+		},
+	}
+	for i := range testCases {
+		tc := testCases[i]
+		b.Run(tc.Name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				enc := jsonschema.NewEncoder(new(bytes.Buffer))
+				enc.Encode(&tc.Schema)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added some benchmarks to test number of allocation / performance for the public API of jsonschema. These changes don't have to be merged, but it shouldn't hurt if they are, as benchmarks are not run by default.

Performance of the JSON Schema package is not considered critical in any way, so these benchmarks are mostly educational, as I want to see how much and changes made to #51 might affect the performance/allocation numbers. Especially the difference between "handwritten" JSON serialization and map allocations would be interesting to see.

Current results on my machine as of 921f47fb4c3713c098b4922f128bf58d65b3dfae:
```
% go test -bench '.*' -benchmem -cpu 1,2,4 -count 2
BenchmarkEncoder/Schema={Fields:{"b":Bool{}}}           	 1000000	      1255 ns/op	     496 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"b":Bool{}}}           	 1000000	      1249 ns/op	     496 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"b":Bool{}}}-2         	 1000000	      1254 ns/op	     496 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"b":Bool{}}}-2         	 1000000	      1228 ns/op	     496 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"b":Bool{}}}-4         	 1000000	      1228 ns/op	     496 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"b":Bool{}}}-4         	 1000000	      1228 ns/op	     496 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{}}}         	 1000000	      1224 ns/op	     480 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{}}}         	 1000000	      1226 ns/op	     480 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{}}}-2       	 1000000	      1210 ns/op	     480 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{}}}-2       	 1000000	      1209 ns/op	     480 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{}}}-4       	 1000000	      1204 ns/op	     480 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{}}}-4       	 1000000	      1220 ns/op	     480 B/op	      14 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{MaxLen:42}}}           	 1000000	      1489 ns/op	     504 B/op	      16 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{MaxLen:42}}}           	 1000000	      1480 ns/op	     504 B/op	      16 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{MaxLen:42}}}-2         	 1000000	      1460 ns/op	     504 B/op	      16 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{MaxLen:42}}}-2         	 1000000	      1461 ns/op	     504 B/op	      16 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{MaxLen:42}}}-4         	 1000000	      1465 ns/op	     504 B/op	      16 allocs/op
BenchmarkEncoder/Schema={Fields:{"s":String{MaxLen:42}}}-4         	 1000000	      1488 ns/op	     504 B/op	      16 allocs/op
BenchmarkEncoder/Schema=Student                                    	  200000	      9604 ns/op	    2528 B/op	      59 allocs/op
BenchmarkEncoder/Schema=Student                                    	  200000	      9422 ns/op	    2528 B/op	      59 allocs/op
BenchmarkEncoder/Schema=Student-2                                  	  200000	      9284 ns/op	    2528 B/op	      59 allocs/op
BenchmarkEncoder/Schema=Student-2                                  	  200000	      9390 ns/op	    2528 B/op	      59 allocs/op
BenchmarkEncoder/Schema=Student-4                                  	  200000	      9340 ns/op	    2528 B/op	      59 allocs/op
BenchmarkEncoder/Schema=Student-4                                  	  200000	      9236 ns/op	    2528 B/op	      59 allocs/op
PASS
```

Machine details:
```
  Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro11,1
      Processor Name: Intel Core i5
      Processor Speed: 2.6 GHz
      Number of Processors: 1
      Total Number of Cores: 2
      L2 Cache (per Core): 256 KB
      L3 Cache: 3 MB
      Memory: 8 GB
```