### PR TITLE
jsonschema: Switch to map based encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1489,7 +1489,40 @@ fmt.Println(b.String()) // Valid JSON Document describing the schema
  - [ ] schema.Dict
  - [ ] schema.AllOf
  - [ ] schema.AnyOf
- - [ ] Custom validators
+ - [x] Custom FieldValidators
+
+### Custom FieldValidators
+
+For a custom `FieldValidator` to support encoding to JSON Schema, it must implement the `jsonschema.Builder` interface:
+
+```go
+// The Builder interface should be implemented by custom schema.FieldValidator implementations to allow JSON Schema
+// serialization.
+type Builder interface {
+	// BuildJSONSchema should return a map containing JSON Schema Draft 4 properties that can be set based on
+	// FieldValidator data. Application specific properties can be added as well, but should not conflict with any
+	// legal JSON Schema keys.
+	BuildJSONSchema() (map[string]interface{}, error)
+}
+```
+
+To easier extend a `FieldValidator` from the `schema` package, you can call `ValidatorBuilder` inside `BuildJSONSchem()`:
+
+```go
+type Email struct {
+	schema.String
+}
+
+func (e Email) BuildJSONSchema() (map[string]interface{}, error) {
+	parentBuilder, _ = jsonschema.ValidatorBuilder(e.String)
+	m, err := parentBuilder.BuildJSONSchema()
+	if err != nil {
+		return nil, err
+	}
+	m["format"] = "email"
+	return m, nil
+}
+```
 
 ## Licenses
 

--- a/schema/encoding/jsonschema/bool.go
+++ b/schema/encoding/jsonschema/bool.go
@@ -1,13 +1,9 @@
 package jsonschema
 
-import (
-	"io"
+import "github.com/rs/rest-layer/schema"
 
-	"github.com/rs/rest-layer/schema"
-)
+type boolBuilder schema.Bool
 
-func encodeBool(w io.Writer, v *schema.Bool) error {
-	ew := errWriter{w: w}
-	ew.writeString(`"type": "boolean"`)
-	return ew.err
+func (v boolBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	return map[string]interface{}{"type": "boolean"}, nil
 }

--- a/schema/encoding/jsonschema/encoder.go
+++ b/schema/encoding/jsonschema/encoder.go
@@ -1,7 +1,7 @@
 package jsonschema
 
 import (
-	"fmt"
+	"encoding/json"
 	"io"
 
 	"github.com/rs/rest-layer/schema"
@@ -11,57 +11,37 @@ import (
 // FieldValidator types in the schema package is supported at the moment. Custom validators are also not yet handled.
 // Attempting to encode a schema containing such fields will result in a ErrNotImplemented error.
 type Encoder struct {
-	io.Writer
+	w io.Writer
 }
 
 // NewEncoder returns a new JSONSchema Encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{w}
+	return &Encoder{w: w}
 }
 
 // Encode writes the JSON Schema representation of s to the stream, followed by a newline character.
 func (e *Encoder) Encode(s *schema.Schema) error {
-	ew := errWriter{w: e.Writer}
-	ew.writeString("{")
-	if ew.err == nil {
-		ew.err = encodeSchema(e.Writer, s)
+	m := make(map[string]interface{})
+	if err := addSchemaProperties(m, s); err != nil {
+		return err
 	}
-	ew.writeString("}\n")
-	return ew.err
+	enc := json.NewEncoder(e.w)
+	return enc.Encode(m)
+
 }
 
-// Wrap IO writer so we can consolidate error handling in a single place. Also track properties written so we know when
-// to emit a separator.
-type errWriter struct {
-	w   io.Writer // writer instance
-	err error     // track errors
+// The Builder interface should be implemented by custom schema.FieldValidator implementations to allow JSON Schema
+// serialization.
+type Builder interface {
+	// BuildJSONSchema should return a map containing JSON Schema Draft 4 properties that can be set based on
+	// FieldValidator data. Application specific properties can be added as well, but should not conflict with any
+	// legal JSON Schema keys.
+	BuildJSONSchema() (map[string]interface{}, error)
 }
 
-// Write ensures compatibility with the io.Writer interface.
-func (ew errWriter) Write(p []byte) (int, error) {
-	if ew.err != nil {
-		return 0, ew.err
-	}
-	return ew.w.Write(p)
-}
+// builderFunc is an adapter that allows pure functions to implement the Builder interface.
+type builderFunc func() (map[string]interface{}, error)
 
-func (ew errWriter) writeFormat(format string, a ...interface{}) {
-	if ew.err != nil {
-		return
-	}
-	_, ew.err = fmt.Fprintf(ew.w, format, a...)
-}
-
-func (ew errWriter) writeString(s string) {
-	if ew.err != nil {
-		return
-	}
-	_, ew.err = ew.w.Write([]byte(s))
-}
-
-func (ew errWriter) writeBytes(b []byte) {
-	if ew.err != nil {
-		return
-	}
-	_, ew.err = ew.w.Write(b)
+func (f builderFunc) BuildJSONSchema() (map[string]interface{}, error) {
+	return f()
 }

--- a/schema/encoding/jsonschema/example_test.go
+++ b/schema/encoding/jsonschema/example_test.go
@@ -14,18 +14,20 @@ func ExampleEncoder() {
 	s := schema.Schema{
 		Fields: schema.Fields{
 			"foo": schema.Field{
-				Required: true,
-				// NOTE: Min is currently encoded as '0E+00', not '0'.
+				Required:  true,
 				Validator: &schema.Float{Boundaries: &schema.Boundaries{Min: 0, Max: math.Inf(1)}},
 			},
 			"bar": schema.Field{
 				Validator: &schema.Integer{},
 			},
 			"baz": schema.Field{
-				ReadOnly:  true,
-				Validator: &schema.String{MaxLen: 42},
+				Description: "baz can not be set by the user",
+				ReadOnly:    true,
+				Validator:   &schema.String{MaxLen: 42},
 			},
-			"foobar": schema.Field{},
+			"foobar": schema.Field{
+				Description: "foobar can hold any valid JSON value",
+			},
 		},
 	}
 	b := new(bytes.Buffer)
@@ -35,25 +37,28 @@ func ExampleEncoder() {
 	json.Indent(b2, b.Bytes(), "", "| ")
 	fmt.Println(b2)
 	// Output: {
-	// | "type": "object",
 	// | "additionalProperties": false,
 	// | "properties": {
 	// | | "bar": {
 	// | | | "type": "integer"
 	// | | },
 	// | | "baz": {
+	// | | | "description": "baz can not be set by the user",
+	// | | | "maxLength": 42,
 	// | | | "readOnly": true,
-	// | | | "type": "string",
-	// | | | "maxLength": 42
+	// | | | "type": "string"
 	// | | },
 	// | | "foo": {
-	// | | | "type": "number",
-	// | | | "minimum": 0E+00
+	// | | | "minimum": 0,
+	// | | | "type": "number"
 	// | | },
-	// | | "foobar": {}
+	// | | "foobar": {
+	// | | | "description": "foobar can hold any valid JSON value"
+	// | | }
 	// | },
 	// | "required": [
 	// | | "foo"
-	// | ]
+	// | ],
+	// | "type": "object"
 	// }
 }

--- a/schema/encoding/jsonschema/float.go
+++ b/schema/encoding/jsonschema/float.go
@@ -1,44 +1,32 @@
 package jsonschema
 
 import (
-	"io"
 	"math"
-	"strconv"
-	"strings"
 
 	"github.com/rs/rest-layer/schema"
 )
 
-func encodeFloat(w io.Writer, v *schema.Float) error {
-	ew := errWriter{w: w}
+type floatBuilder schema.Float
 
-	ew.writeString(`"type": "number"`)
+func (v floatBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	m := map[string]interface{}{
+		"type": "number",
+	}
+
 	if len(v.Allowed) > 0 {
-		var allowed []string
-		for _, value := range v.Allowed {
-			allowed = append(allowed, strconv.FormatFloat(value, 'E', -1, 64))
-		}
-		ew.writeFormat(`, "enum": [%s]`, strings.Join(allowed, ","))
+		m["enum"] = v.Allowed
 	}
-	if ew.err == nil {
-		ew.err = boundariesToJSONSchema(w, v.Boundaries)
+	if v.Boundaries != nil {
+		addBoundariesProperties(m, v.Boundaries)
 	}
-	return ew.err
+	return m, nil
 }
 
-// boundariesToJSONSchema writes JSON Schema keys and values based on b, prefixed by a comma and without curly braces,
-// to w. The prefixing comma is only written if at least one key/value pair is also written.
-func boundariesToJSONSchema(w io.Writer, b *schema.Boundaries) error {
-	if b == nil {
-		return nil
-	}
-	ew := errWriter{w: w}
-
+func addBoundariesProperties(m map[string]interface{}, b *schema.Boundaries) {
 	if !math.IsNaN(b.Min) && !math.IsInf(b.Min, -1) {
-		ew.writeFormat(`, "minimum": %s`, strconv.FormatFloat(b.Min, 'E', -1, 64))
+		m["minimum"] = b.Min
 	}
 	if !math.IsNaN(b.Max) && !math.IsInf(b.Max, 1) {
-		ew.writeFormat(`, "maximum": %s`, strconv.FormatFloat(b.Max, 'E', -1, 64))
+		m["maximum"] = b.Max
 	}
-	return ew.err
 }

--- a/schema/encoding/jsonschema/integer.go
+++ b/schema/encoding/jsonschema/integer.go
@@ -1,26 +1,19 @@
 package jsonschema
 
-import (
-	"io"
-	"strconv"
-	"strings"
+import "github.com/rs/rest-layer/schema"
 
-	"github.com/rs/rest-layer/schema"
-)
+type integerBuilder schema.Integer
 
-func encodeInteger(w io.Writer, v *schema.Integer) error {
-	ew := errWriter{w: w}
+func (v integerBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	m := map[string]interface{}{
+		"type": "integer",
+	}
 
-	ew.writeString(`"type": "integer"`)
 	if len(v.Allowed) > 0 {
-		var allowed []string
-		for _, value := range v.Allowed {
-			allowed = append(allowed, strconv.FormatInt(int64(value), 10))
-		}
-		ew.writeFormat(`, "enum": [%s]`, strings.Join(allowed, ","))
+		m["enum"] = v.Allowed
 	}
-	if ew.err == nil {
-		ew.err = boundariesToJSONSchema(w, v.Boundaries)
+	if v.Boundaries != nil {
+		addBoundariesProperties(m, v.Boundaries)
 	}
-	return ew.err
+	return m, nil
 }

--- a/schema/encoding/jsonschema/object.go
+++ b/schema/encoding/jsonschema/object.go
@@ -1,15 +1,28 @@
 package jsonschema
 
 import (
-	"io"
+	"fmt"
 
 	"github.com/rs/rest-layer/schema"
 )
 
-func encodeObject(w io.Writer, v *schema.Object) error {
-	ew := errWriter{w: w}
-	if ew.err == nil && v.Schema != nil {
-		ew.err = encodeSchema(w, v.Schema)
+type objectBuilder schema.Object
+
+var (
+	//ErrNoSchema is returned when trying to JSON Encode a schema.Object with the Schema property set to nil.
+	ErrNoSchema = fmt.Errorf("no schema defined for object")
+)
+
+func (v objectBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	if v.Schema == nil {
+		return nil, ErrNoSchema
 	}
-	return ew.err
+
+	m := map[string]interface{}{}
+	err := addSchemaProperties(m, v.Schema)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+
 }

--- a/schema/encoding/jsonschema/string.go
+++ b/schema/encoding/jsonschema/string.go
@@ -1,32 +1,25 @@
 package jsonschema
 
-import (
-	"fmt"
-	"io"
-	"strconv"
-	"strings"
+import "github.com/rs/rest-layer/schema"
 
-	"github.com/rs/rest-layer/schema"
-)
+type stringBuilder schema.String
 
-func encodeString(w io.Writer, v *schema.String) error {
-	ew := errWriter{w: w}
-	ew.writeString(`"type": "string"`)
+func (v stringBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	m := map[string]interface{}{
+		"type": "string",
+	}
+
 	if v.Regexp != "" {
-		ew.writeFormat(`, "pattern": %q`, v.Regexp)
+		m["pattern"] = v.Regexp
 	}
 	if len(v.Allowed) > 0 {
-		var allowed []string
-		for _, value := range v.Allowed {
-			allowed = append(allowed, fmt.Sprintf("%q", value))
-		}
-		ew.writeFormat(`, "enum": [%s]`, strings.Join(allowed, ", "))
+		m["enum"] = v.Allowed
 	}
 	if v.MinLen > 0 {
-		ew.writeFormat(`, "minLength": %s`, strconv.FormatInt(int64(v.MinLen), 10))
+		m["minLength"] = v.MinLen
 	}
 	if v.MaxLen > 0 {
-		ew.writeFormat(`, "maxLength": %s`, strconv.FormatInt(int64(v.MaxLen), 10))
+		m["maxLength"] = v.MaxLen
 	}
-	return ew.err
+	return m, nil
 }

--- a/schema/encoding/jsonschema/time.go
+++ b/schema/encoding/jsonschema/time.go
@@ -1,13 +1,12 @@
 package jsonschema
 
-import (
-	"io"
+import "github.com/rs/rest-layer/schema"
 
-	"github.com/rs/rest-layer/schema"
-)
+type timeBuilder schema.Time
 
-func encodeTime(w io.Writer, v *schema.Time) error {
-	ew := errWriter{w: w}
-	ew.writeString(`"type": "string", "format": "date-time"`)
-	return ew.err
+func (v timeBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"type":   "string",
+		"format": "date-time",
+	}, nil
 }


### PR DESCRIPTION
Provides a public interface for #35, and switches the internal encoding
logic to rely on maps, as propsed in #51. This makes the implementation
simpler and more straight forward.

Compared to the poposed solution 1 in #35 that would rely on passing an
io.Writer to an encoder method, this solution will more easily handle a
corner-case where a custom validator writes zero bytes to the io.Writer.

The reduction in complexity does not come for free though. This looks to
be 4x slower for very tiny schemas, and aproximately 2x slower for small
schemas. As jsonschema is used as API documentation, and can be easily
cached, this performance loss should still be quite acceptable.