### PR TITLE
Issue #34: JSON Schema support for more types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,14 +1476,14 @@ fmt.Println(b.String()) // Valid JSON Document describing the schema
 
  - [x] schema.Schema
  - [x] schema.Bool
- - [ ] schema.Null
+ - [x] schema.Null
  - [x] schema.Float
  - [x] schema.Integer
  - [x] schema.String
  - [x] schema.Time
- - [ ] schema.URL
- - [ ] schema.IP
- - [ ] schema.Password
+ - [x] schema.URL (limited support)
+ - [x] schema.IP
+ - [x] schema.Password
  - [x] schema.Array
  - [x] schema.Object
  - [ ] schema.Dict

--- a/schema/encoding/jsonschema/ip.go
+++ b/schema/encoding/jsonschema/ip.go
@@ -1,0 +1,16 @@
+package jsonschema
+
+import "github.com/rs/rest-layer/schema"
+
+type ipBuilder schema.IP
+
+func (v ipBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	m := map[string]interface{}{
+		"type": "string",
+		"oneOf": []map[string]interface{}{
+			{"format": "ipv4"},
+			{"format": "ipv6"},
+		},
+	}
+	return m, nil
+}

--- a/schema/encoding/jsonschema/ip_test.go
+++ b/schema/encoding/jsonschema/ip_test.go
@@ -1,0 +1,28 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/rs/rest-layer/schema"
+)
+
+func TestIPValidatorEncode(t *testing.T) {
+	testCase := encoderTestCase{
+		name: ``,
+		schema: schema.Schema{
+			Fields: schema.Fields{
+				"ip": {
+					Validator: &schema.IP{},
+				},
+			},
+		},
+		customValidate: fieldValidator("ip", `{
+			"type": "string",
+			"oneOf": [
+				{"format": "ipv4"},
+				{"format": "ipv6"}
+			]
+		}`),
+	}
+	testCase.Run(t)
+}

--- a/schema/encoding/jsonschema/null.go
+++ b/schema/encoding/jsonschema/null.go
@@ -1,0 +1,9 @@
+package jsonschema
+
+import "github.com/rs/rest-layer/schema"
+
+type nullBuilder schema.Null
+
+func (v nullBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	return map[string]interface{}{"type": "null"}, nil
+}

--- a/schema/encoding/jsonschema/null_test.go
+++ b/schema/encoding/jsonschema/null_test.go
@@ -6,17 +6,17 @@ import (
 	"github.com/rs/rest-layer/schema"
 )
 
-func TestBoolValidatorEncode(t *testing.T) {
+func TestNullValidatorEncode(t *testing.T) {
 	testCase := encoderTestCase{
 		name: ``,
 		schema: schema.Schema{
 			Fields: schema.Fields{
-				"b": {
-					Validator: &schema.Bool{},
+				"n": {
+					Validator: &schema.Null{},
 				},
 			},
 		},
-		customValidate: fieldValidator("b", `{"type": "boolean"}`),
+		customValidate: fieldValidator("n", `{"type": "null"}`),
 	}
 	testCase.Run(t)
 }

--- a/schema/encoding/jsonschema/password.go
+++ b/schema/encoding/jsonschema/password.go
@@ -1,0 +1,19 @@
+package jsonschema
+
+import "github.com/rs/rest-layer/schema"
+
+type passwordBuilder schema.Password
+
+func (v passwordBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	m := map[string]interface{}{
+		"type":   "string",
+		"format": "password",
+	}
+	if v.MinLen > 0 {
+		m["minLength"] = v.MinLen
+	}
+	if v.MaxLen > 0 {
+		m["maxLength"] = v.MaxLen
+	}
+	return m, nil
+}

--- a/schema/encoding/jsonschema/password_test.go
+++ b/schema/encoding/jsonschema/password_test.go
@@ -1,0 +1,66 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/rs/rest-layer/schema"
+)
+
+func TestPasswordValidatorEncode(t *testing.T) {
+	testCases := []encoderTestCase{
+		{
+			name: `MinLen=0,MaxLen=0`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"p": {
+						Validator: &schema.Password{},
+					},
+				},
+			},
+			customValidate: fieldValidator("p", `{"type": "string", "format": "password"}`),
+		},
+		{
+			name: `MinLen=3,MaxLen=23`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"p": {
+						Validator: &schema.Password{
+							MinLen: 3,
+							MaxLen: 23,
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("p", `{"type": "string", "format": "password", "minLength": 3, "maxLength": 23}`),
+		},
+		{
+			name: `MaxLen=23`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"s": {
+						Validator: &schema.String{
+							MaxLen: 23,
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("s", `{"type": "string", "maxLength": 23}`),
+		},
+		{
+			name: `MinLen=3`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"s": {
+						Validator: &schema.String{
+							MinLen: 3,
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("s", `{"type": "string", "minLength": 3}`),
+		},
+	}
+	for i := range testCases {
+		testCases[i].Run(t)
+	}
+}

--- a/schema/encoding/jsonschema/schema.go
+++ b/schema/encoding/jsonschema/schema.go
@@ -83,10 +83,18 @@ func ValidatorBuilder(v schema.FieldValidator) (Builder, error) {
 	switch t := v.(type) {
 	case Builder:
 		return t, nil
+	case *schema.Null:
+		return (*nullBuilder)(t), nil
 	case *schema.Bool:
 		return (*boolBuilder)(t), nil
 	case *schema.String:
 		return (*stringBuilder)(t), nil
+	case *schema.Password:
+		return (*passwordBuilder)(t), nil
+	case *schema.IP:
+		return (*ipBuilder)(t), nil
+	case *schema.URL:
+		return (*urlBuilder)(t), nil
 	case *schema.Time:
 		return (*timeBuilder)(t), nil
 	case *schema.Integer:

--- a/schema/encoding/jsonschema/string_test.go
+++ b/schema/encoding/jsonschema/string_test.go
@@ -1,5 +1,3 @@
-// +build go1.7
-
 package jsonschema_test
 
 import (

--- a/schema/encoding/jsonschema/url.go
+++ b/schema/encoding/jsonschema/url.go
@@ -1,0 +1,14 @@
+package jsonschema
+
+import "github.com/rs/rest-layer/schema"
+
+type urlBuilder schema.URL
+
+func (v urlBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	// TODO: Currently the JSON Schema representation ignores any validation configuration set in schema.URL.
+	m := map[string]interface{}{
+		"type":   "string",
+		"format": "uri",
+	}
+	return m, nil
+}

--- a/schema/encoding/jsonschema/url_test.go
+++ b/schema/encoding/jsonschema/url_test.go
@@ -6,17 +6,20 @@ import (
 	"github.com/rs/rest-layer/schema"
 )
 
-func TestBoolValidatorEncode(t *testing.T) {
+func TestURLValidatorEncode(t *testing.T) {
 	testCase := encoderTestCase{
 		name: ``,
 		schema: schema.Schema{
 			Fields: schema.Fields{
-				"b": {
-					Validator: &schema.Bool{},
+				"url": {
+					Validator: &schema.URL{},
 				},
 			},
 		},
-		customValidate: fieldValidator("b", `{"type": "boolean"}`),
+		customValidate: fieldValidator("ip", `{
+			"type": "string",
+			"format": "uri"
+		}`),
 	}
 	testCase.Run(t)
 }


### PR DESCRIPTION
Fixes #34 by adding JSON Schema support for FieldValidators:
- Null
- Password
- IP
- URL (limited support)

As for URL, none of the validation parameters in schema.URL is taken
into account by the JSON Schema encoding at this point in time.