### PR TITLE
JSON Schema support for schema.Dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,7 +1459,7 @@ See [Hystrix godoc](https://godoc.org/github.com/afex/hystrix-go/hystrix) for mo
 
 ## JSONSchema
 
-An incomplete but stil useful JSONSchema implementation that covers many common use cases for Schema. Goal is to try and match the draft-04 spec. Patches welcome.
+An incomplete but still useful JSONSchema implementation that covers many common use cases for Schema. Goal is to try and match the draft-04 spec. Patches are welcome.
 
 ```go
 import "github.com/rs/rest-layer/schema/jsonschema"
@@ -1474,11 +1474,12 @@ fmt.Println(b.String()) // Valid JSON Document describing the schema
 
 ### Supported FieldValidators
 
+ - [x] Custom FieldValidators
  - [ ] schema.AllOf
  - [ ] schema.AnyOf
  - [x] schema.Array
  - [x] schema.Bool
- - [ ] schema.Dict
+ - [x] schema.Dict (limited support)
  - [x] schema.Float
  - [x] schema.IP
  - [x] schema.Integer
@@ -1489,7 +1490,6 @@ fmt.Println(b.String()) // Valid JSON Document describing the schema
  - [x] schema.String
  - [x] schema.Time
  - [x] schema.URL (limited support)
- - [x] Custom FieldValidators
 
 ### Custom FieldValidators
 
@@ -1523,6 +1523,18 @@ func (e Email) BuildJSONSchema() (map[string]interface{}, error) {
 	return m, nil
 }
 ```
+
+### schema.Dict Limitations
+
+`schema.Dict` only support `nil` and `schema.String` as `KeysValidator` values. Note that some less common combinations of `schema.String` attributes will lead to usage of an `allOf` construct with duplicated schemas for values. This is to avoid usage of regular expression expansions that only a subset of implementations actually support.
+
+The limitation in `KeysValidator` values arise because JSON Schema draft 4 (and draft 5) support for key validation is limited to [properties, patternProperties and additionalProperties](https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.4). This essentially means that there can be no JSON Schema object supplied for key validation, but that we need to rely on exact match (properties), regular expressions (patternProperties) or no key validation (additionalProperties).
+
+## schema.URL Limitations
+
+The current serialization of `schema.URL` always returns a schema `{"type": "string", "format": "uri"}`, ignoring any struct attributes that affect the actual validation within rest-layer. The JSON Schema is thus not completely accurate for this validator.
+
+Note that JSON Schema draft 5 adds (uriref)[https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.7], which could allow us to at least document whether `AllowRelative` is `true` or `false`. JSON Schema also allow application specific additional formats to be defined, but it's not practical to create a custom format for any possible struct attribute combination.
 
 ## Licenses
 

--- a/schema/encoding/jsonschema/dict.go
+++ b/schema/encoding/jsonschema/dict.go
@@ -1,0 +1,101 @@
+package jsonschema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/rs/rest-layer/schema"
+)
+
+type dictBuilder schema.Dict
+
+var (
+	//ErrKeysValidatorNotSupported is returned when Dict.KeysValidator is not a *schema.String instance or nil.
+	ErrKeysValidatorNotSupported = errors.New("KeysValidator type not supported")
+)
+
+func (v dictBuilder) BuildJSONSchema() (map[string]interface{}, error) {
+	m := map[string]interface{}{
+		"type": "object",
+	}
+	var patterns []string
+
+	// Retrieve keys validator pattern(s).
+	switch kv := v.KeysValidator.(type) {
+	case *schema.String:
+		if len(kv.Allowed) > 0 {
+			patterns = append(patterns,
+				fmt.Sprintf("^(%s)$", strings.Join(kv.Allowed, "|")),
+			)
+
+		}
+		if kv.MaxLen > 0 || kv.MinLen > 0 {
+			if kv.MaxLen == kv.MinLen {
+				patterns = append(patterns,
+					fmt.Sprintf("^.{%d}$", kv.MinLen),
+				)
+			} else if kv.MaxLen > 0 {
+				patterns = append(patterns,
+					fmt.Sprintf("^.{%d,%d}$", kv.MinLen, kv.MaxLen),
+				)
+			} else {
+				patterns = append(patterns,
+					fmt.Sprintf("^.{%d,}$", kv.MinLen),
+				)
+			}
+		}
+		if kv.Regexp != "" {
+			patterns = append(patterns, kv.Regexp)
+		}
+	case nil:
+	default:
+		return nil, ErrKeysValidatorNotSupported
+	}
+
+	// Retrieve values validator JSON schema.
+	var valuesSchema map[string]interface{}
+	if v.ValuesValidator != nil {
+		b, err := ValidatorBuilder(v.ValuesValidator)
+		if err != nil {
+			return nil, err
+		}
+		valuesSchema, err = b.BuildJSONSchema()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		valuesSchema = map[string]interface{}{}
+	}
+
+	// Compose JSON Schema.
+	switch len(patterns) {
+	case 0:
+		if len(valuesSchema) > 0 {
+			m["additionalProperties"] = valuesSchema
+		} else {
+			m["additionalProperties"] = true
+		}
+	case 1:
+		m["additionalProperties"] = false
+		m["patternProperties"] = map[string]interface{}{
+			patterns[0]: valuesSchema,
+		}
+	default:
+		// With the lack of logical AND in O(n) regex implementations (e.g. the Go implementation), we have to
+		// build an allOff clause (with duplicated schemas for values validation) whenever multiple key patterns
+		// are found.
+		allOf := make([]map[string]map[string]interface{}, 0, len(patterns))
+		for i := range patterns {
+			allOf = append(allOf, map[string]map[string]interface{}{
+				"patternProperties": {
+					patterns[i]: valuesSchema,
+				},
+			})
+		}
+		m["additionalProperties"] = false
+		m["allOf"] = allOf
+	}
+
+	return m, nil
+}

--- a/schema/encoding/jsonschema/dict_test.go
+++ b/schema/encoding/jsonschema/dict_test.go
@@ -1,0 +1,286 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/rs/rest-layer/schema"
+)
+
+func TestDictValidatorEncode(t *testing.T) {
+	testCases := []encoderTestCase{
+		{
+			name: `KeysValidator=nil,ValuesValidator=nil}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{"type": "object", "additionalProperties": true}`),
+		},
+		{
+			name: `KeysValidator=Integer{}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.Integer{},
+						},
+					},
+				},
+			},
+			expectError: "KeysValidator type not supported",
+		},
+		{
+			name: `KeysValidator=String{}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{"type": "object", "additionalProperties": true}`),
+		},
+		{
+			name: `ValuesValidator=Integer{}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							ValuesValidator: &schema.Integer{},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": {
+					"type": "integer"
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{Regexp:"re"}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{Regexp: "re"},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"re": {}
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{Regexp:"re"},ValuesValidator=Integer{}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator:   &schema.String{Regexp: "re"},
+							ValuesValidator: &schema.Integer{},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"re": {
+						"type": "integer"
+					}
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{Allowed:["match1"]}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								Allowed: []string{"match1"},
+							},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"^(match1)$": {}
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{Allowed:["match1","match2"]}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								Allowed: []string{"match1", "match2"},
+							},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"^(match1|match2)$": {}
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{Regexp:"tch",Allowed:["match1","match2"]}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								Regexp:  "tch",
+								Allowed: []string{"match1", "match2"},
+							},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"allOf": [
+					{"patternProperties": {"^(match1|match2)$": {}}},
+					{"patternProperties": {"tch": {}}}
+				]
+			}`),
+		},
+		{
+			name: `KeysValidator=String{Regexp:"tch",Allowed:["match1","match2"]},ValuesValidator=Integer{}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								Regexp:  "tch",
+								Allowed: []string{"match1", "match2"},
+							},
+							ValuesValidator: &schema.Integer{},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"allOf": [
+					{"patternProperties": {"^(match1|match2)$": {"type": "integer"}}},
+					{"patternProperties": {"tch": {"type": "integer"}}}
+				]
+			}`),
+		},
+		{
+			name: `KeysValidator=String{MinLen:3},ValuesValidator=nil}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								MinLen: 3,
+							},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"^.{3,}$": {}
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{MaxLen:4}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								MaxLen: 4,
+							},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"^.{0,4}$": {}
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{MinLen:3,MaxLen:4}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								MinLen: 3,
+								MaxLen: 4,
+							},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"^.{3,4}$": {}
+				}
+			}`),
+		},
+		{
+			name: `KeysValidator=String{MinLen:3,MaxLen:3}"`,
+			schema: schema.Schema{
+				Fields: schema.Fields{
+					"d": {
+						Validator: &schema.Dict{
+							KeysValidator: &schema.String{
+								MinLen: 3,
+								MaxLen: 3,
+							},
+						},
+					},
+				},
+			},
+			customValidate: fieldValidator("d", `{
+				"type": "object",
+				"additionalProperties": false,
+				"patternProperties": {
+					"^.{3}$": {}
+				}
+			}`),
+		},
+	}
+	for i := range testCases {
+		testCases[i].Run(t)
+	}
+}

--- a/schema/encoding/jsonschema/object.go
+++ b/schema/encoding/jsonschema/object.go
@@ -1,7 +1,7 @@
 package jsonschema
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/rs/rest-layer/schema"
 )
@@ -10,7 +10,7 @@ type objectBuilder schema.Object
 
 var (
 	//ErrNoSchema is returned when trying to JSON Encode a schema.Object with the Schema property set to nil.
-	ErrNoSchema = fmt.Errorf("no schema defined for object")
+	ErrNoSchema = errors.New("no schema defined for object")
 )
 
 func (v objectBuilder) BuildJSONSchema() (map[string]interface{}, error) {

--- a/schema/encoding/jsonschema/schema.go
+++ b/schema/encoding/jsonschema/schema.go
@@ -105,6 +105,8 @@ func ValidatorBuilder(v schema.FieldValidator) (Builder, error) {
 		return (*arrayBuilder)(t), nil
 	case *schema.Object:
 		return (*objectBuilder)(t), nil
+	case *schema.Dict:
+		return (*dictBuilder)(t), nil
 	default:
 		return nil, ErrNotImplemented
 	}


### PR DESCRIPTION
This commits resolves #33 by adding JSON Schema support for schema.Dict.
The support limits KeysValidator instances to be a schema.String
instance or nil as explained in the README.