### PR TITLE
Replaces ErrUnauthorized by ErrForbidden (breaking change)

### DIFF
--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -45,7 +45,7 @@ func NewBasicAuthHandler(users *resource.Resource) func(next http.Handler) http.
 				// Lookup the user by its id
 				ctx := r.Context()
 				user, err := users.Get(ctx, u)
-				if user != nil && err == resource.ErrUnauthorized {
+				if user != nil && err == resource.ErrForbidden {
 					// Ignore unauthorized errors set by ourselves
 					err = nil
 				}
@@ -82,7 +82,7 @@ func (a AuthResourceHook) OnFind(ctx context.Context, q *query.Query, offset, li
 	// Reject unauthorized users
 	user, found := UserFromContext(ctx)
 	if !found {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	// Add a predicate to the query to restrict to result on objects owned by this user
 	q.Predicate = append(q.Predicate, query.Equal{Field: a.UserField, Value: user.ID})
@@ -98,7 +98,7 @@ func (a AuthResourceHook) OnGot(ctx context.Context, item **resource.Item, err *
 	// Reject unauthorized users
 	user, found := UserFromContext(ctx)
 	if !found {
-		*err = resource.ErrUnauthorized
+		*err = resource.ErrForbidden
 		return
 	}
 	// Check access right
@@ -113,13 +113,13 @@ func (a AuthResourceHook) OnInsert(ctx context.Context, items []*resource.Item) 
 	// Reject unauthorized users
 	user, found := UserFromContext(ctx)
 	if !found {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	// Check access right
 	for _, item := range items {
 		if u, found := item.Payload[a.UserField]; found {
 			if u != user.ID {
-				return resource.ErrUnauthorized
+				return resource.ErrForbidden
 			}
 		} else {
 			// If no user set for the item, set it to current user
@@ -134,15 +134,15 @@ func (a AuthResourceHook) OnUpdate(ctx context.Context, item *resource.Item, ori
 	// Reject unauthorized users
 	user, found := UserFromContext(ctx)
 	if !found {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	// Check access right
 	if u, found := original.Payload[a.UserField]; !found || u != user.ID {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	// Ensure user field is not altered
 	if u, found := item.Payload[a.UserField]; !found || u != user.ID {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	return nil
 }
@@ -152,11 +152,11 @@ func (a AuthResourceHook) OnDelete(ctx context.Context, item *resource.Item) err
 	// Reject unauthorized users
 	user, found := UserFromContext(ctx)
 	if !found {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	// Check access right
 	if item.Payload[a.UserField] != user.ID {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	return nil
 }
@@ -166,7 +166,7 @@ func (a AuthResourceHook) OnClear(ctx context.Context, q *query.Query) error {
 	// Reject unauthorized users
 	user, found := UserFromContext(ctx)
 	if !found {
-		return resource.ErrUnauthorized
+		return resource.ErrForbidden
 	}
 	// Add a predicate to the query to restrict to impact of the clear on objects owned by this user
 	q.Predicate = append(q.Predicate, query.Equal{Field: a.UserField, Value: user.ID})

--- a/resource/errors.go
+++ b/resource/errors.go
@@ -5,9 +5,9 @@ import "errors"
 var (
 	// ErrNotFound is returned when the requested resource can't be found.
 	ErrNotFound = errors.New("Not Found")
-	// ErrUnauthorized is returned when the requested resource can be accessed
+	// ErrForbidden is returned when the requested resource can not be accessed
 	// by the requestor for security reason.
-	ErrUnauthorized = errors.New("Unauthorized")
+	ErrForbidden = errors.New("Forbidden")
 	// ErrConflict happens when another thread or node modified the data
 	// concurrently with our own thread in such a way we can't securely apply
 	// the requested changes.

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -10,8 +10,8 @@ import (
 var (
 	// ErrNotFound represents a 404 HTTP error.
 	ErrNotFound = &Error{http.StatusNotFound, "Not Found", nil}
-	// ErrUnauthorized represents a 401 HTTP error.
-	ErrUnauthorized = &Error{http.StatusUnauthorized, "Unauthorized", nil}
+	// ErrForbidden represents a 403 HTTP error.
+	ErrForbidden = &Error{http.StatusForbidden, "Forbidden", nil}
 	// ErrPreconditionFailed happens when a conditional request condition is not met.
 	ErrPreconditionFailed = &Error{http.StatusPreconditionFailed, "Precondition Failed", nil}
 	// ErrConflict happens when another thread or node modified the data
@@ -58,8 +58,8 @@ func NewError(err error) *Error {
 		return ErrGatewayTimeout
 	case resource.ErrNotFound:
 		return ErrNotFound
-	case resource.ErrUnauthorized:
-		return ErrUnauthorized
+	case resource.ErrForbidden:
+		return ErrForbidden
 	case resource.ErrConflict:
 		return ErrConflict
 	case resource.ErrNotImplemented:

--- a/rest/errors_test.go
+++ b/rest/errors_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewError(t *testing.T) {
 	assert.Equal(t, ErrClientClosedRequest, NewError(context.Canceled))
 	assert.Equal(t, ErrGatewayTimeout, NewError(context.DeadlineExceeded))
-	assert.Equal(t, ErrUnauthorized, NewError(resource.ErrUnauthorized))
+	assert.Equal(t, ErrForbidden, NewError(resource.ErrForbidden))
 	assert.Equal(t, ErrNotFound, NewError(resource.ErrNotFound))
 	assert.Equal(t, ErrConflict, NewError(resource.ErrConflict))
 	assert.Equal(t, ErrNotImplemented, NewError(resource.ErrNotImplemented))


### PR DESCRIPTION
This is just a start on #120.

In the resource and rest packages, ErrUnauthorized is replaced by
ErrForbidden. It is presumably more useful to let rest-layer hooks
return the new error over an error that will be translated into a 401
response by the `rest` package. Despite it's name, 401 Unauthorized
responses should only be return when a user is not authenticated. 403
Forbidden errors is a much better fit for any kind of permission (or
authentication issues) that is discovered as late as within a resource
hook.

401 Unauthorized HTTP response, is best returned by an authentication
middleware only, as this middleware will have the opportunity to set an
appropriate WWW-Authenticate challenge for the given application, while
the rest-layer `rest` package may not.

~PS! This change does not update the examples!~