### PR TITLE
Fix 129: Set Connection.Field on Resource.Bind()

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -143,7 +143,8 @@ func (r *Resource) Bind(name, field string, s schema.Schema, h Storer, c Conf) *
 	r.validator.fallback.Fields[name] = schema.Field{
 		ReadOnly: true,
 		Validator: &schema.Connection{
-			Path: "." + name,
+			Path:  "." + name,
+			Field: field,
 		},
 		Params: schema.Params{
 			"skip": schema.Param{

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -26,7 +26,8 @@ func TestResourceBind(t *testing.T) {
 			"bar": {
 				ReadOnly: true,
 				Validator: &schema.Connection{
-					Path: ".bar",
+					Path:  ".bar",
+					Field: "foo",
 				},
 				Params: schema.Params{
 					"skip": schema.Param{


### PR DESCRIPTION
Forgot to add one file when commiting the last PR to fix #129.
This commit makes sure embedding actually works when using the
Resource.Bind() method.