### PR TITLE
Add support for bool parameters

### DIFF
--- a/schema/query/projection.go
+++ b/schema/query/projection.go
@@ -75,6 +75,8 @@ func (pf ProjectionField) String() string {
 				buf.WriteString(strconv.Quote(v))
 			case float64:
 				buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+			case bool:
+				buf.WriteString(fmt.Sprintf("%t", v))
 			default:
 				buf.WriteString(fmt.Sprintf("%q", v))
 			}

--- a/schema/query/projection_evaluator_test.go
+++ b/schema/query/projection_evaluator_test.go
@@ -78,13 +78,17 @@ func TestProjectionEval(t *testing.T) {
 			"with_params": {
 				Params: schema.Params{
 					"foo": {Validator: schema.Integer{}},
+					"bar": {Validator: schema.Bool{}},
 				},
 				Handler: func(ctx context.Context, value interface{}, params map[string]interface{}) (interface{}, error) {
 					if val, found := params["foo"]; found {
 						if val == -1 {
 							return nil, errors.New("some error")
 						}
-						return fmt.Sprintf("param is %d", val), nil
+						return fmt.Sprintf("param foo is %d", val), nil
+					}
+					if val, found := params["bar"]; found {
+						return fmt.Sprintf("param bar is %t", val), nil
 					}
 					return "no param", nil
 				},
@@ -138,7 +142,21 @@ func TestProjectionEval(t *testing.T) {
 			`with_params(foo:1)`,
 			`{"with_params":"value"}`,
 			nil,
-			`{"with_params":"param is 1"}`,
+			`{"with_params":"param foo is 1"}`,
+		},
+		{
+			"Parmeters",
+			`with_params(bar:true)`,
+			`{"with_params":"value"}`,
+			nil,
+			`{"with_params":"param bar is true"}`,
+		},
+		{
+			"Parmeters",
+			`with_params(bar:false)`,
+			`{"with_params":"value"}`,
+			nil,
+			`{"with_params":"param bar is false"}`,
 		},
 		{
 			"Parmeters/NoParam", // Handler is not called.

--- a/schema/query/projection_parser.go
+++ b/schema/query/projection_parser.go
@@ -213,9 +213,28 @@ func (p *projectionParser) scanParamValue() (interface{}, error) {
 		return p.parseString()
 	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-':
 		return p.parseNumber()
+	case 't', 'f':
+		return p.parseBool()
 	default:
 		return nil, fmt.Errorf("looking for value at char %d", p.pos)
 	}
+}
+
+// parseBool parses a Boolean value.
+func (p *projectionParser) parseBool() (bool, error) {
+	switch p.peek() {
+	case 't':
+		if p.pos+4 <= len(p.exp) && p.exp[p.pos:p.pos+4] == "true" {
+			p.pos += 4
+			return true, nil
+		}
+	case 'f':
+		if p.pos+5 <= len(p.exp) && p.exp[p.pos:p.pos+5] == "false" {
+			p.pos += 5
+			return false, nil
+		}
+	}
+	return false, errors.New("not a boolean")
 }
 
 // parseNumber parses a number as float.

--- a/schema/query/projection_parser_test.go
+++ b/schema/query/projection_parser_test.go
@@ -82,6 +82,16 @@ func TestParseProjection(t *testing.T) {
 			Projection{{Name: "foo", Params: map[string]interface{}{"bar": -0.2}}},
 		},
 		{
+			`foo(baz:true)`,
+			nil,
+			Projection{{Name: "foo", Params: map[string]interface{}{"baz": true}}},
+		},
+		{
+			`foo(baz:false)`,
+			nil,
+			Projection{{Name: "foo", Params: map[string]interface{}{"baz": false}}},
+		},
+		{
 			`foo(bar : -0.2 , baz = "zab")`,
 			nil,
 			Projection{{Name: "foo", Params: map[string]interface{}{"bar": -0.2, "baz": "zab"}}},

--- a/schema/query/projection_validator_test.go
+++ b/schema/query/projection_validator_test.go
@@ -22,6 +22,12 @@ func TestProjectionValidate(t *testing.T) {
 					"foo": {
 						Validator: schema.Integer{},
 					},
+					"bar": {
+						Validator: schema.Bool{},
+					},
+					"foobar": {
+						Validator: schema.String{},
+					},
 				},
 			},
 		},
@@ -32,12 +38,18 @@ func TestProjectionValidate(t *testing.T) {
 	}{
 		{`parent{child},simple`, nil},
 		{`with_params(foo:1)`, nil},
+		{`with_params(bar:true)`, nil},
+		{`with_params(bar:false)`, nil},
+		{`with_params(foobar:"foobar")`, nil},
 		{`foo`, errors.New("foo: unknown field")},
 		{`simple{child}`, errors.New("simple: field as no children")},
 		{`parent{foo}`, errors.New("parent.foo: unknown field")},
 		{`simple(foo:1)`, errors.New("simple: params not allowed")},
-		{`with_params(bar:1)`, errors.New("with_params: unsupported param name: bar")},
+		{`with_params(baz:1)`, errors.New("with_params: unsupported param name: baz")},
 		{`with_params(foo:"a string")`, errors.New("with_params: invalid param `foo' value: not an integer")},
+		{`with_params(foo:3.14)`, errors.New("with_params: invalid param `foo' value: not an integer")},
+		{`with_params(bar:1)`, errors.New("with_params: invalid param `bar' value: not a Boolean")},
+		{`with_params(foobar:true)`, errors.New("with_params: invalid param `foobar' value: not a string")},
 	}
 	for i := range cases {
 		tc := cases[i]


### PR DESCRIPTION
This commit adds support for adding bool parameters to a schema field.
For consistency with other FieldValidators, the error message was also
changed to state "boolean" as lower case.

Fixes issue #140.