### PR TITLE
Add HTTP HEAD specialization for `resource.ItemList`

### DIFF
--- a/rest/method_head.go
+++ b/rest/method_head.go
@@ -1,0 +1,54 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/rs/rest-layer/resource"
+)
+
+// listHead handles HEAD resquests on a resource URL. Returns no payload
+func listHead(ctx context.Context, r *http.Request, route *RouteMatch) (status int, headers http.Header, body interface{}) {
+	forceTotal := false
+	rsc := route.Resource()
+	switch rsc.Conf().ForceTotal {
+	case resource.TotalOptIn:
+		forceTotal = route.Params.Get("total") == "1"
+	case resource.TotalAlways:
+		forceTotal = true
+	case resource.TotalDenied:
+		if route.Params.Get("total") == "1" {
+			return 422, nil, &Error{422, "Cannot use `total' parameter: denied by configuration", nil}
+		}
+	}
+	q, e := route.Query()
+	if e != nil {
+		return e.Code, nil, e
+	}
+	list := &resource.ItemList{
+		Total: -1,
+		Items: []*resource.Item{},
+	}
+	var err error
+	if forceTotal {
+		list.Total, err = rsc.Count(ctx, q)
+		// If Storer doesn't implement Counter interface,
+		// fallback to listGet implementation
+		if err == resource.ErrNotImplemented {
+			return listGet(ctx, r, route)
+		}
+	}
+	if err != nil {
+		e = NewError(err)
+		return e.Code, nil, e
+	}
+	if win := q.Window; win != nil {
+		if win.Offset > 0 {
+			list.Offset = win.Offset
+		}
+		if win.Limit >= 0 {
+			list.Limit = win.Limit
+		}
+	}
+	return 200, nil, list
+}

--- a/rest/method_head_test.go
+++ b/rest/method_head_test.go
@@ -1,0 +1,56 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/rs/rest-layer-mem"
+	"github.com/rs/rest-layer/resource"
+	"github.com/rs/rest-layer/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlerHead(t *testing.T) {
+	s := mem.NewHandler()
+	s.Insert(context.TODO(), []*resource.Item{
+		{ID: "1"},
+		{ID: "2"},
+		{ID: "3"},
+		{ID: "4"},
+		{ID: "5"},
+	})
+	index := resource.NewIndex()
+	test := index.Bind("test", schema.Schema{}, s, resource.DefaultConf)
+	r, _ := http.NewRequest("HEAD", "/test", nil)
+	rm := &RouteMatch{
+		Method: "HEAD",
+		ResourcePath: []*ResourcePathComponent{
+			&ResourcePathComponent{
+				Name:     "test",
+				Resource: test,
+			},
+		},
+		Params: url.Values{},
+	}
+	status, headers, body := listHead(context.TODO(), r, rm)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Nil(t, headers)
+	if assert.IsType(t, body, &resource.ItemList{}) {
+		l := body.(*resource.ItemList)
+		assert.Len(t, l.Items, 0)
+		assert.Equal(t, -1, l.Total)
+	}
+
+	rm.Params.Set("total", "1")
+
+	status, headers, body = listHead(context.TODO(), r, rm)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Nil(t, headers)
+	if assert.IsType(t, body, &resource.ItemList{}) {
+		l := body.(*resource.ItemList)
+		assert.Len(t, l.Items, 0)
+		assert.Equal(t, 5, l.Total)
+	}
+}

--- a/rest/util.go
+++ b/rest/util.go
@@ -31,7 +31,9 @@ func getMethodHandler(isItem bool, method string) methodHandler {
 		switch method {
 		case http.MethodOptions:
 			return listOptions
-		case http.MethodHead, http.MethodGet:
+		case http.MethodHead:
+			return listHead
+		case http.MethodGet:
 			return listGet
 		case http.MethodPost:
 			return listPost


### PR DESCRIPTION
This is generic optimization for HTTP HEAD, where resource list is being queried.
No data is pulled out from the storage layer.