### PR TITLE
Resolver datarace

### DIFF
--- a/schema/query/projection_evaluator.go
+++ b/schema/query/projection_evaluator.go
@@ -50,7 +50,8 @@ func evalProjection(ctx context.Context, p Projection, payload map[string]interf
 			p = append(p, ProjectionField{Name: fn})
 		}
 	}
-	for _, pf := range p {
+	for i := range p {
+		pf := p[i]
 		name := pf.Name
 		// Handle aliasing
 		if pf.Alias != "" {


### PR DESCRIPTION
This fixes nasty data-race within execution of `resourceBatchSolver`. #148 
When getting multiple sub-resources:
```
GET http://192.168.0.103:3001/api/clients/59a1a17aeaba9ebd0180abb0?fields=address,services{id,name,ownOrder,insuraceCompany},visits{name,appointmentDT,duration}
```

the last projection `{name,appointmentDT,duration}` is applied to all sub-resources (`services` and `visits`).
This was traced back to shared variable `pf` which was used in a loop, and reused by Golang `range` operator.

Didn't found in which test file to put this test case exactly. I can supply demo-app if requested.