### PR TITLE
Add a way to say "all fields" in the projection

### DIFF
--- a/schema/query/projection_evaluator_test.go
+++ b/schema/query/projection_evaluator_test.go
@@ -200,6 +200,62 @@ func TestProjectionEval(t *testing.T) {
 			nil,
 			`{"connection":[{"name":"third"}]}`,
 		},
+		{
+			"ValidStar",
+			`*`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			nil,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+		},
+		{
+			"Double/InvalidStar",
+			`*,*`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			errors.New("*,*: invalid value: * must be the only field"),
+			``,
+		},
+		{
+			"Parent/InvalidStar1",
+			`*,parent`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			errors.New("*,parent: invalid value: * must be the only field"),
+			``,
+		},
+		{
+			"Parent/InvalidStar2",
+			`parent,*`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			errors.New("parent,*: invalid value: * must be the only field"),
+			``,
+		},
+		{
+			"Child/ValidStar",
+			`parent{*}`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			nil,
+			`{"parent":{"child":"value"}}`,
+		},
+		{
+			"Child/InvalidStar1",
+			`parent{*,child}`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			errors.New("parent.*,child: invalid value: * must be the only field"),
+			``,
+		},
+		{
+			"Child/InvalidStar2",
+			`parent{child,*}`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			errors.New("parent.child,*: invalid value: * must be the only field"),
+			``,
+		},
+		{
+			"Parent/Child/InvalidStar",
+			`parent{child,*},*`,
+			`{"parent":{"child":"value"},"simple":"value"}`,
+			errors.New("parent,*: invalid value: * must be the only field"),
+			``,
+		},
 	}
 
 	for i := range cases {

--- a/schema/query/projection_parser.go
+++ b/schema/query/projection_parser.go
@@ -178,7 +178,12 @@ func (p *projectionParser) scanFieldName() string {
 	field := []byte{}
 	for p.more() {
 		c := p.peek()
-		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' || c == '*' {
+			// Allow * only by itself.
+			if (c == '*' && len(field) != 0) || (c != '*' && len(field) > 1 && field[0] == '*') {
+				return ""
+			}
+
 			field = append(field, c)
 			p.pos++
 			continue

--- a/schema/query/projection_validator.go
+++ b/schema/query/projection_validator.go
@@ -8,6 +8,10 @@ import (
 
 // Validate validates the projection field against the provided validator.
 func (pf ProjectionField) Validate(validator schema.Validator) error {
+	if pf.Name == "*" && len(pf.Children) == 0 && len(pf.Params) == 0 {
+		return nil
+	}
+
 	def := validator.GetField(pf.Name)
 	if def == nil {
 		return fmt.Errorf("%s: unknown field", pf.Name)

--- a/schema/query/projection_validator_test.go
+++ b/schema/query/projection_validator_test.go
@@ -34,32 +34,38 @@ func TestProjectionValidate(t *testing.T) {
 	}
 	cases := []struct {
 		projection string
-		err        error
+		parseErr   error
+		validErr   error
 	}{
-		{`parent{child},simple`, nil},
-		{`with_params(foo:1)`, nil},
-		{`with_params(bar:true)`, nil},
-		{`with_params(bar:false)`, nil},
-		{`with_params(foobar:"foobar")`, nil},
-		{`foo`, errors.New("foo: unknown field")},
-		{`simple{child}`, errors.New("simple: field as no children")},
-		{`parent{foo}`, errors.New("parent.foo: unknown field")},
-		{`simple(foo:1)`, errors.New("simple: params not allowed")},
-		{`with_params(baz:1)`, errors.New("with_params: unsupported param name: baz")},
-		{`with_params(foo:"a string")`, errors.New("with_params: invalid param `foo' value: not an integer")},
-		{`with_params(foo:3.14)`, errors.New("with_params: invalid param `foo' value: not an integer")},
-		{`with_params(bar:1)`, errors.New("with_params: invalid param `bar' value: not a Boolean")},
-		{`with_params(foobar:true)`, errors.New("with_params: invalid param `foobar' value: not a string")},
+		{`parent{child},simple`, nil, nil},
+		{`with_params(foo:1)`, nil, nil},
+		{`with_params(bar:true)`, nil, nil},
+		{`with_params(bar:false)`, nil, nil},
+		{`with_params(foobar:"foobar")`, nil, nil},
+		{`foo`, nil, errors.New("foo: unknown field")},
+		{`simple{child}`, nil, errors.New("simple: field as no children")},
+		{`parent{foo}`, nil, errors.New("parent.foo: unknown field")},
+		{`simple(foo:1)`, nil, errors.New("simple: params not allowed")},
+		{`with_params(baz:1)`, nil, errors.New("with_params: unsupported param name: baz")},
+		{`with_params(foo:"a string")`, nil, errors.New("with_params: invalid param `foo' value: not an integer")},
+		{`with_params(foo:3.14)`, nil, errors.New("with_params: invalid param `foo' value: not an integer")},
+		{`with_params(bar:1)`, nil, errors.New("with_params: invalid param `bar' value: not a Boolean")},
+		{`with_params(foobar:true)`, nil, errors.New("with_params: invalid param `foobar' value: not a string")},
+		{`*`, nil, nil},
+		{`parent,*`, nil, nil},
+		{`*,parent`, nil, nil},
+		{`*parent`, errors.New("looking for field name at char 2"), nil},
+		{`parent*`, errors.New("looking for field name at char 6"), nil},
 	}
 	for i := range cases {
 		tc := cases[i]
 		t.Run(tc.projection, func(t *testing.T) {
 			pr, err := ParseProjection(tc.projection)
-			if err != nil {
-				t.Errorf("ParseProjection unexpected error: %v", err)
+			if !reflect.DeepEqual(err, tc.parseErr) {
+				t.Errorf("ParseProjection error = %v, wanted: %v", err, tc.parseErr)
 			}
-			if err = pr.Validate(s); !reflect.DeepEqual(err, tc.err) {
-				t.Errorf("Projection.Validate error = %v, wanted: %v", err, tc.err)
+			if err = pr.Validate(s); !reflect.DeepEqual(err, tc.validErr) {
+				t.Errorf("Projection.Validate error = %v, wanted: %v", err, tc.validErr)
 			}
 		})
 	}


### PR DESCRIPTION
This enables us to get implicitly all fields of a resource, when sub-resources are requested #147 
```
GET http://192.168.0.103:3001/api/clients/59a1a17aeaba9ebd0180abb0?fields=*,services{ownOrder},visits{name,appointmentDT,duration}
```

This makes the following two requests equivalent:
```
GET http://192.168.0.103:3001/api/clients/59a1a17aeaba9ebd0180abb0?fields=*,services{*},visits{name,appointmentDT,duration}

GET http://192.168.0.103:3001/api/clients/59a1a17aeaba9ebd0180abb0?fields=*,services,visits{name,appointmentDT,duration}
```