### PR TITLE
Use "Skip" even if no "Limit" is specified

### DIFF
--- a/schema/query/window.go
+++ b/schema/query/window.go
@@ -14,6 +14,9 @@ type Window struct {
 // Page creates a Window using pagination.
 func Page(page, perPage, skip int) *Window {
 	if perPage < 0 {
+		if skip > 0 {
+			return &Window{Offset: skip, Limit: perPage}
+		}
 		return nil
 	}
 	if page < 1 {


### PR DESCRIPTION
Without this patch, query like this:
```
GET http://192.168.0.103:3001/api/clients?skip=1&filter={"isBlacklisted":false}
```
`skip` parameter will be unused, because there is no `limit` parameter specified. I view this as non-consistent behavior, so this patch fixes that.