### PR TITLE
routing: HEAD must behave just like GET, except returning the body

### DIFF
--- a/rest/routing.go
+++ b/rest/routing.go
@@ -195,10 +195,7 @@ func (r *RouteMatch) Query() (*query.Query, *Error) {
 	}
 	// Parse query string params.
 	switch r.Method {
-	case "HEAD":
-		// request empty response
-		q.Window = &query.Window{Offset: 0, Limit: 0}
-	case "GET":
+	case "HEAD", "GET":
 		limit := -1
 		if l, found, err := getUintParam(r.Params, "limit"); found {
 			if err != nil {


### PR DESCRIPTION
Fix HTTP HEAD request to respect `Window` parameters, and to make it function just like GET.