### PR TITLE
Return weak ETags and add ETag HTTP header to itemList response

### DIFF
--- a/rest/method_item_delete_test.go
+++ b/rest/method_item_delete_test.go
@@ -92,7 +92,7 @@ func TestHandlerDeleteItemEtag(t *testing.T) {
 		Fields: schema.Fields{"foo": {Filterable: true}},
 	}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("DELETE", "/test/2", nil)
-	r.Header.Set("If-Match", "a")
+	r.Header.Set("If-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{
@@ -123,7 +123,7 @@ func TestHandlerDeleteItemWrongEtag(t *testing.T) {
 		Fields: schema.Fields{"foo": {Filterable: true}},
 	}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("DELETE", "/test/2", nil)
-	r.Header.Set("If-Match", "a")
+	r.Header.Set("If-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{

--- a/rest/method_item_get_test.go
+++ b/rest/method_item_get_test.go
@@ -134,7 +134,7 @@ func TestHandlerGetItemEtagMatch(t *testing.T) {
 	index := resource.NewIndex()
 	test := index.Bind("test", schema.Schema{}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("GET", "/test/2", nil)
-	r.Header.Set("If-None-Match", "a")
+	r.Header.Set("If-None-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{
@@ -161,7 +161,7 @@ func TestHandlerGetItemEtagDontMatch(t *testing.T) {
 	index := resource.NewIndex()
 	test := index.Bind("test", schema.Schema{}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("GET", "/test/2", nil)
-	r.Header.Set("If-None-Match", "a")
+	r.Header.Set("If-None-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{

--- a/rest/method_item_patch_test.go
+++ b/rest/method_item_patch_test.go
@@ -207,7 +207,7 @@ func TestHandlerPatchItemReplaceEtagMatch(t *testing.T) {
 	})
 	test := index.Bind("test", schema.Schema{Fields: schema.Fields{"id": {}}}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("PATCH", "/test/1", bytes.NewBufferString(`{"id": "1"}`))
-	r.Header.Set("If-Match", "a")
+	r.Header.Set("If-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{
@@ -230,7 +230,7 @@ func TestHandlerPatchItemReplaceEtagDontMatch(t *testing.T) {
 	})
 	test := index.Bind("test", schema.Schema{Fields: schema.Fields{"id": {}}}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("PATCH", "/test/1", bytes.NewBufferString(`{"id": "1"}`))
-	r.Header.Set("If-Match", "a")
+	r.Header.Set("If-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{

--- a/rest/method_item_put_test.go
+++ b/rest/method_item_put_test.go
@@ -272,7 +272,7 @@ func TestHandlerPutItemReplaceEtagMatch(t *testing.T) {
 	})
 	test := index.Bind("test", schema.Schema{Fields: schema.Fields{"id": {}}}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("PUT", "/test/1", bytes.NewBufferString(`{"id": "1"}`))
-	r.Header.Set("If-Match", "a")
+	r.Header.Set("If-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{
@@ -295,7 +295,7 @@ func TestHandlerPutItemReplaceEtagDontMatch(t *testing.T) {
 	})
 	test := index.Bind("test", schema.Schema{Fields: schema.Fields{"id": {}}}, s, resource.DefaultConf)
 	r, _ := http.NewRequest("PUT", "/test/1", bytes.NewBufferString(`{"id": "1"}`))
-	r.Header.Set("If-Match", "a")
+	r.Header.Set("If-Match", "W/a")
 	rm := &RouteMatch{
 		ResourcePath: []*ResourcePathComponent{
 			&ResourcePathComponent{

--- a/rest/response_test.go
+++ b/rest/response_test.go
@@ -82,7 +82,7 @@ func TestDefaultResponseFormatterFormatItem(t *testing.T) {
 
 	h = http.Header{}
 	rctx, payload = rf.FormatItem(ctx, h, &resource.Item{ETag: "1234"}, false)
-	assert.Equal(t, http.Header{"Etag": []string{`"1234"`}}, h)
+	assert.Equal(t, http.Header{"Etag": []string{`W/"1234"`}}, h)
 	assert.Equal(t, rctx, ctx)
 	assert.Equal(t, map[string]interface{}(nil), payload)
 }
@@ -95,7 +95,7 @@ func TestDefaultResponseFormatterFormatList(t *testing.T) {
 		Total: -1,
 		Items: []*resource.Item{{Payload: map[string]interface{}{"foo": "bar"}}},
 	}, false)
-	assert.Equal(t, http.Header{}, h)
+	assert.Equal(t, http.Header{"Etag": []string{`W/"d41d8cd98f00b204e9800998ecf8427e"`}}, h)
 	assert.Equal(t, rctx, ctx)
 	assert.Equal(t, []map[string]interface{}{{"foo": "bar"}}, payload)
 
@@ -104,7 +104,7 @@ func TestDefaultResponseFormatterFormatList(t *testing.T) {
 		Total: -1,
 		Items: []*resource.Item{{Payload: map[string]interface{}{"foo": "bar"}}},
 	}, true)
-	assert.Equal(t, http.Header{}, h)
+	assert.Equal(t, http.Header{"Etag": []string{`W/"d41d8cd98f00b204e9800998ecf8427e"`}}, h)
 	assert.Equal(t, rctx, ctx)
 	assert.Equal(t, nil, payload)
 
@@ -114,7 +114,7 @@ func TestDefaultResponseFormatterFormatList(t *testing.T) {
 		Offset: 2,
 		Items:  []*resource.Item{{Payload: map[string]interface{}{"foo": "bar"}}},
 	}, false)
-	assert.Equal(t, http.Header{"X-Total": []string{"1"}, "X-Offset": []string{"2"}}, h)
+	assert.Equal(t, http.Header{"X-Total": []string{"1"}, "X-Offset": []string{"2"}, "Etag": []string{`W/"d41d8cd98f00b204e9800998ecf8427e"`}}, h)
 	assert.Equal(t, rctx, ctx)
 	assert.Equal(t, []map[string]interface{}{{"foo": "bar"}}, payload)
 
@@ -123,7 +123,7 @@ func TestDefaultResponseFormatterFormatList(t *testing.T) {
 		Total: -1,
 		Items: []*resource.Item{{ETag: "123", Payload: map[string]interface{}{"foo": "bar"}}},
 	}, false)
-	assert.Equal(t, http.Header{}, h)
+	assert.Equal(t, http.Header{"Etag": []string{`W/"202cb962ac59075b964b07152d234b70"`}}, h)
 	assert.Equal(t, rctx, ctx)
 	assert.Equal(t, []map[string]interface{}{{"foo": "bar", "_etag": "123"}}, payload)
 }

--- a/rest/util.go
+++ b/rest/util.go
@@ -126,11 +126,13 @@ func compareEtag(etag, baseEtag string) bool {
 	if etag == "" {
 		return false
 	}
-	if etag == baseEtag {
-		return true
-	}
-	if l := len(etag); l == len(baseEtag)+2 && l > 3 && etag[0] == '"' && etag[l-1] == '"' && etag[1:l-1] == baseEtag {
-		return true
+	if strings.HasPrefix(etag, "W/") {
+		if etag[2:] == baseEtag {
+			return true
+		}
+		if l := len(etag); l == len(baseEtag)+4 && l > 4 && etag[2] == '"' && etag[l-1] == '"' && etag[3:l-1] == baseEtag {
+			return true
+		}
 	}
 	return false
 }

--- a/rest/util_test.go
+++ b/rest/util_test.go
@@ -141,10 +141,10 @@ func TestSetAllowHeader(t *testing.T) {
 }
 
 func TestCompareEtag(t *testing.T) {
-	assert.True(t, compareEtag(`abc`, `abc`))
-	assert.True(t, compareEtag(`"abc"`, `abc`))
-	assert.False(t, compareEtag(`'abc'`, `abc`))
-	assert.False(t, compareEtag(`"abc`, `abc`))
+	assert.True(t, compareEtag(`W/abc`, `abc`))
+	assert.True(t, compareEtag(`W/"abc"`, `abc`))
+	assert.False(t, compareEtag(`W/'abc'`, `abc`))
+	assert.False(t, compareEtag(`W/"abc`, `abc`))
 	assert.False(t, compareEtag(``, `abc`))
 	assert.False(t, compareEtag(`"cba"`, `abc`))
 }
@@ -219,7 +219,7 @@ func TestRequestCheckIntegrityEtagMissmatch(t *testing.T) {
 
 func TestRequestCheckIntegrityEtagMatch(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/", nil)
-	r.Header.Set("If-Match", "foo")
+	r.Header.Set("If-Match", "W/foo")
 	err := checkIntegrityRequest(r, &resource.Item{ETag: "foo"})
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Pickup the long-hanging fruit, and add `ETag` to itemList response.