### PR TITLE
Fix schema.Dict.GetField bug

### DIFF
--- a/schema/connection.go
+++ b/schema/connection.go
@@ -8,6 +8,7 @@ type Connection struct {
 	Field string
 }
 
+// Validate implements the FieldValidator interface.
 func (v *Connection) Validate(value interface{}) (interface{}, error) {
 	// No validation perform at this time.
 	return value, nil

--- a/schema/dict.go
+++ b/schema/dict.go
@@ -73,8 +73,10 @@ func (v Dict) Validate(value interface{}) (interface{}, error) {
 
 // GetField implements the FieldGetter interface.
 func (v Dict) GetField(name string) *Field {
-	if _, err := v.KeysValidator.Validate(name); err != nil {
-		return nil
+	if v.KeysValidator != nil {
+		if _, err := v.KeysValidator.Validate(name); err != nil {
+			return nil
+		}
 	}
 	return &v.Values
 }

--- a/schema/dict_test.go
+++ b/schema/dict_test.go
@@ -3,6 +3,7 @@
 package schema_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/rs/rest-layer/schema"
@@ -115,4 +116,34 @@ func TestDictValidate(t *testing.T) {
 	for i := range testCases {
 		testCases[i].Run(t)
 	}
+}
+
+func TestDictGetField(t *testing.T) {
+	f := schema.Field{Description: "foobar", Filterable: true}
+	t.Run("{KeysValidator=nil}.GetField(valid)", func(t *testing.T) {
+		d := schema.Dict{KeysValidator: nil, Values: f}
+		if gf := d.GetField("something"); !reflect.DeepEqual(f, *gf) {
+			t.Errorf("d.GetField(valid) returned %#v, expected %#v", *gf, f)
+		}
+	})
+
+	t.Run("{KeysValidator=String}.GetField(valid)", func(t *testing.T) {
+		d := schema.Dict{
+			KeysValidator: schema.String{Allowed: []string{"foo", "bar"}},
+			Values:        f,
+		}
+		if gf := d.GetField("foo"); !reflect.DeepEqual(f, *gf) {
+			t.Errorf("d.GetField(valid) returned %#v, expected %#v", *gf, f)
+		}
+	})
+
+	t.Run("{KeysValidator=String}.GetField(invalid)", func(t *testing.T) {
+		d := schema.Dict{
+			KeysValidator: schema.String{Allowed: []string{"foo", "bar"}},
+			Values:        f,
+		}
+		if gf := d.GetField("invalid"); gf != nil {
+			t.Errorf("d.GetField(invalid) returned %#v, expected nil", *gf)
+		}
+	})
 }


### PR DESCRIPTION
fixes GetField(string) to work when KeysValidator is not set, and ads
tests for it. Using asserts library for consistent output compared
to existing tests.