### PR TITLE
Avoid rest package calling OnFind/OnFound hooks on PATCH

### DIFF
--- a/resource/context.go
+++ b/resource/context.go
@@ -1,0 +1,19 @@
+package resource
+
+import "context"
+
+type ctxKey int
+
+const (
+	ctxKeyDisableHooks ctxKey = iota
+)
+
+// WithDisableHooks returns a new context where hooks are marked not to run.
+func WithDisableHooks(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyDisableHooks, true)
+}
+
+func hooksDisabled(ctx context.Context) bool {
+	b, ok := ctx.Value(ctxKeyDisableHooks).(bool)
+	return ok && b
+}

--- a/resource/hook.go
+++ b/resource/hook.go
@@ -259,6 +259,9 @@ func (h *eventHandler) use(e interface{}) error {
 }
 
 func (h *eventHandler) onFind(ctx context.Context, q *query.Query) error {
+	if hooksDisabled(ctx) {
+		return nil
+	}
 	for _, e := range h.onFindH {
 		if err := e.OnFind(ctx, q); err != nil {
 			return err
@@ -268,12 +271,18 @@ func (h *eventHandler) onFind(ctx context.Context, q *query.Query) error {
 }
 
 func (h *eventHandler) onFound(ctx context.Context, q *query.Query, list **ItemList, err *error) {
+	if hooksDisabled(ctx) {
+		return
+	}
 	for _, e := range h.onFoundH {
 		e.OnFound(ctx, q, list, err)
 	}
 }
 
 func (h *eventHandler) onGet(ctx context.Context, id interface{}) error {
+	if hooksDisabled(ctx) {
+		return nil
+	}
 	for _, e := range h.onGetH {
 		if err := e.OnGet(ctx, id); err != nil {
 			return err
@@ -283,12 +292,18 @@ func (h *eventHandler) onGet(ctx context.Context, id interface{}) error {
 }
 
 func (h *eventHandler) onGot(ctx context.Context, item **Item, err *error) {
+	if hooksDisabled(ctx) {
+		return
+	}
 	for _, e := range h.onGotH {
 		e.OnGot(ctx, item, err)
 	}
 }
 
 func (h *eventHandler) onInsert(ctx context.Context, items []*Item) error {
+	if hooksDisabled(ctx) {
+		return nil
+	}
 	for _, e := range h.onInsertH {
 		if err := e.OnInsert(ctx, items); err != nil {
 			return err
@@ -298,12 +313,18 @@ func (h *eventHandler) onInsert(ctx context.Context, items []*Item) error {
 }
 
 func (h *eventHandler) onInserted(ctx context.Context, items []*Item, err *error) {
+	if hooksDisabled(ctx) {
+		return
+	}
 	for _, e := range h.onInsertedH {
 		e.OnInserted(ctx, items, err)
 	}
 }
 
 func (h *eventHandler) onUpdate(ctx context.Context, item *Item, original *Item) error {
+	if hooksDisabled(ctx) {
+		return nil
+	}
 	for _, e := range h.onUpdateH {
 		if err := e.OnUpdate(ctx, item, original); err != nil {
 			return err
@@ -313,12 +334,18 @@ func (h *eventHandler) onUpdate(ctx context.Context, item *Item, original *Item)
 }
 
 func (h *eventHandler) onUpdated(ctx context.Context, item *Item, original *Item, err *error) {
+	if hooksDisabled(ctx) {
+		return
+	}
 	for _, e := range h.onUpdatedH {
 		e.OnUpdated(ctx, item, original, err)
 	}
 }
 
 func (h *eventHandler) onDelete(ctx context.Context, item *Item) error {
+	if hooksDisabled(ctx) {
+		return nil
+	}
 	for _, e := range h.onDeleteH {
 		if err := e.OnDelete(ctx, item); err != nil {
 			return err
@@ -328,12 +355,18 @@ func (h *eventHandler) onDelete(ctx context.Context, item *Item) error {
 }
 
 func (h *eventHandler) onDeleted(ctx context.Context, item *Item, err *error) {
+	if hooksDisabled(ctx) {
+		return
+	}
 	for _, e := range h.onDeletedH {
 		e.OnDeleted(ctx, item, err)
 	}
 }
 
 func (h *eventHandler) onClear(ctx context.Context, q *query.Query) error {
+	if hooksDisabled(ctx) {
+		return nil
+	}
 	for _, e := range h.onClearH {
 		if err := e.OnClear(ctx, q); err != nil {
 			return err
@@ -343,6 +376,9 @@ func (h *eventHandler) onClear(ctx context.Context, q *query.Query) error {
 }
 
 func (h *eventHandler) onCleared(ctx context.Context, q *query.Query, deleted *int, err *error) {
+	if hooksDisabled(ctx) {
+		return
+	}
 	for _, e := range h.onClearedH {
 		e.OnCleared(ctx, q, deleted, err)
 	}

--- a/resource/hook_test.go
+++ b/resource/hook_test.go
@@ -29,14 +29,14 @@ func TestHookUseFind(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	err = h.onFind(nil, nil)
+	err = h.onFind(context.Background(), nil)
 	assert.True(t, called)
 
 	err = h.use(FindEventHandlerFunc(func(ctx context.Context, q *query.Query) error {
 		return errors.New("error")
 	}))
 	assert.NoError(t, err)
-	err = h.onFind(nil, nil)
+	err = h.onFind(context.Background(), nil)
 	assert.EqualError(t, err, "error")
 }
 
@@ -59,7 +59,7 @@ func TestHookUseFound(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onFound(nil, nil, nil, nil)
+	h.onFound(context.Background(), nil, nil, nil)
 	assert.True(t, called)
 
 	err = h.use(FoundEventHandlerFunc(func(ctx context.Context, q *query.Query, list **ItemList, err *error) {
@@ -69,7 +69,7 @@ func TestHookUseFound(t *testing.T) {
 	assert.NoError(t, err)
 	var list *ItemList
 	err = nil
-	h.onFound(nil, nil, &list, &err)
+	h.onFound(context.Background(), nil, &list, &err)
 	assert.EqualError(t, err, "error")
 	assert.NotNil(t, list)
 }
@@ -94,14 +94,14 @@ func TestHookUseGet(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onGet(nil, nil)
+	h.onGet(context.Background(), nil)
 	assert.True(t, called)
 
 	err = h.use(GetEventHandlerFunc(func(ctx context.Context, id interface{}) error {
 		return errors.New("error")
 	}))
 	assert.NoError(t, err)
-	err = h.onGet(nil, nil)
+	err = h.onGet(context.Background(), nil)
 	assert.EqualError(t, err, "error")
 }
 
@@ -124,7 +124,7 @@ func TestHookUseGot(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onGot(nil, nil, nil)
+	h.onGot(context.Background(), nil, nil)
 	assert.True(t, called)
 
 	err = h.use(GotEventHandlerFunc(func(ctx context.Context, item **Item, err *error) {
@@ -134,7 +134,7 @@ func TestHookUseGot(t *testing.T) {
 	assert.NoError(t, err)
 	var item *Item
 	err = nil
-	h.onGot(nil, &item, &err)
+	h.onGot(context.Background(), &item, &err)
 	assert.EqualError(t, err, "error")
 	assert.NotNil(t, item)
 }
@@ -159,14 +159,14 @@ func TestHookUseInsert(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onInsert(nil, nil)
+	h.onInsert(context.Background(), nil)
 	assert.True(t, called)
 
 	err = h.use(InsertEventHandlerFunc(func(ctx context.Context, items []*Item) error {
 		return errors.New("error")
 	}))
 	assert.NoError(t, err)
-	err = h.onInsert(nil, nil)
+	err = h.onInsert(context.Background(), nil)
 	assert.EqualError(t, err, "error")
 }
 
@@ -189,7 +189,7 @@ func TestHookUseInserted(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onInserted(nil, nil, nil)
+	h.onInserted(context.Background(), nil, nil)
 	assert.True(t, called)
 
 	err = h.use(InsertedEventHandlerFunc(func(ctx context.Context, items []*Item, err *error) {
@@ -197,7 +197,7 @@ func TestHookUseInserted(t *testing.T) {
 	}))
 	assert.NoError(t, err)
 	err = nil
-	h.onInserted(nil, nil, &err)
+	h.onInserted(context.Background(), nil, &err)
 	assert.EqualError(t, err, "error")
 }
 
@@ -221,14 +221,14 @@ func TestHookUseUpdate(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onUpdate(nil, nil, nil)
+	h.onUpdate(context.Background(), nil, nil)
 	assert.True(t, called)
 
 	err = h.use(UpdateEventHandlerFunc(func(ctx context.Context, item *Item, original *Item) error {
 		return errors.New("error")
 	}))
 	assert.NoError(t, err)
-	err = h.onUpdate(nil, nil, nil)
+	err = h.onUpdate(context.Background(), nil, nil)
 	assert.EqualError(t, err, "error")
 }
 
@@ -251,7 +251,7 @@ func TestHookUseUpdated(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onUpdated(nil, nil, nil, nil)
+	h.onUpdated(context.Background(), nil, nil, nil)
 	assert.True(t, called)
 
 	err = h.use(UpdatedEventHandlerFunc(func(ctx context.Context, item *Item, original *Item, err *error) {
@@ -259,7 +259,7 @@ func TestHookUseUpdated(t *testing.T) {
 	}))
 	assert.NoError(t, err)
 	err = nil
-	h.onUpdated(nil, nil, nil, &err)
+	h.onUpdated(context.Background(), nil, nil, &err)
 	assert.EqualError(t, err, "error")
 }
 
@@ -283,14 +283,14 @@ func TestHookUseDelete(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onDelete(nil, nil)
+	h.onDelete(context.Background(), nil)
 	assert.True(t, called)
 
 	err = h.use(DeleteEventHandlerFunc(func(ctx context.Context, item *Item) error {
 		return errors.New("error")
 	}))
 	assert.NoError(t, err)
-	err = h.onDelete(nil, nil)
+	err = h.onDelete(context.Background(), nil)
 	assert.EqualError(t, err, "error")
 }
 
@@ -313,7 +313,7 @@ func TestHookUseDeleted(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 1)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
-	h.onDeleted(nil, nil, nil)
+	h.onDeleted(context.Background(), nil, nil)
 	assert.True(t, called)
 
 	err = h.use(DeletedEventHandlerFunc(func(ctx context.Context, item *Item, err *error) {
@@ -321,7 +321,7 @@ func TestHookUseDeleted(t *testing.T) {
 	}))
 	assert.NoError(t, err)
 	err = nil
-	h.onDeleted(nil, nil, &err)
+	h.onDeleted(context.Background(), nil, &err)
 	assert.EqualError(t, err, "error")
 }
 
@@ -345,14 +345,14 @@ func TestHookUseClear(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 1)
 	assert.Len(t, h.onClearedH, 0)
-	h.onClear(nil, nil)
+	h.onClear(context.Background(), nil)
 	assert.True(t, called)
 
 	err = h.use(ClearEventHandlerFunc(func(ctx context.Context, q *query.Query) error {
 		return errors.New("error")
 	}))
 	assert.NoError(t, err)
-	err = h.onClear(nil, nil)
+	err = h.onClear(context.Background(), nil)
 	assert.EqualError(t, err, "error")
 }
 
@@ -376,7 +376,7 @@ func TestHookUseCleared(t *testing.T) {
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 1)
 	deleted := 0
-	h.onCleared(nil, nil, &deleted, nil)
+	h.onCleared(context.Background(), nil, &deleted, nil)
 	assert.True(t, called)
 
 	err = h.use(ClearedEventHandlerFunc(func(ctx context.Context, q *query.Query, deleted *int, err *error) {
@@ -385,7 +385,7 @@ func TestHookUseCleared(t *testing.T) {
 	}))
 	assert.NoError(t, err)
 	err = nil
-	h.onCleared(nil, nil, &deleted, &err)
+	h.onCleared(context.Background(), nil, &deleted, &err)
 	assert.EqualError(t, err, "error")
 	assert.Equal(t, 2, deleted)
 }
@@ -406,4 +406,317 @@ func TestHookUseNonEventHandler(t *testing.T) {
 	assert.Len(t, h.onDeletedH, 0)
 	assert.Len(t, h.onClearH, 0)
 	assert.Len(t, h.onClearedH, 0)
+}
+
+type allHooks struct {
+	numCalled *int
+}
+
+func (h allHooks) OnFind(ctx context.Context, q *query.Query) error {
+	*h.numCalled++
+	return nil
+}
+
+func (h allHooks) OnFound(ctx context.Context, query *query.Query, list **ItemList, err *error) {
+	*h.numCalled++
+}
+
+func (h allHooks) OnGet(ctx context.Context, id interface{}) error {
+	*h.numCalled++
+	return nil
+}
+
+func (h allHooks) OnGot(ctx context.Context, item **Item, err *error) {
+	*h.numCalled++
+}
+
+func (h allHooks) OnInsert(ctx context.Context, items []*Item) error {
+	*h.numCalled++
+	return nil
+}
+
+func (h allHooks) OnInserted(ctx context.Context, items []*Item, err *error) {
+	*h.numCalled++
+}
+
+func (h allHooks) OnUpdate(ctx context.Context, item *Item, original *Item) error {
+	*h.numCalled++
+	return nil
+}
+
+func (h allHooks) OnUpdated(ctx context.Context, item *Item, original *Item, err *error) {
+	*h.numCalled++
+}
+
+func (h allHooks) OnDelete(ctx context.Context, item *Item) error {
+	*h.numCalled++
+	return nil
+}
+
+func (h allHooks) OnDeleted(ctx context.Context, item *Item, err *error) {
+	*h.numCalled++
+}
+
+func (h allHooks) OnClear(ctx context.Context, q *query.Query) error {
+	*h.numCalled++
+	return nil
+}
+
+func (h allHooks) OnCleared(ctx context.Context, q *query.Query, deleted *int, err *error) {
+	*h.numCalled++
+}
+
+func TestHookUseAll(t *testing.T) {
+	var numCalled int
+
+	h := eventHandler{}
+	if err := h.use(allHooks{&numCalled}); err != nil {
+		t.Fatal("test setup failed, h.use(hook{}) returned unexpected error: ", err)
+	}
+	if len(h.onFoundH) != 1 {
+		t.Error("len(h.onFoundH) != 1")
+	}
+	if len(h.onGetH) != 1 {
+		t.Error("len(h.onGetH) != 1")
+	}
+	if len(h.onGotH) != 1 {
+		t.Error("len(h.onGotH) != 1")
+	}
+	if len(h.onInsertH) != 1 {
+		t.Error("len(h.onInsertH) != 1")
+	}
+	if len(h.onInsertedH) != 1 {
+		t.Error("len(h.onInsertedH) != 1")
+	}
+	if len(h.onUpdateH) != 1 {
+		t.Error("len(h.onUpdateH) != 1")
+	}
+	if len(h.onUpdatedH) != 1 {
+		t.Error("len(h.onUpdatedH) != 1")
+	}
+	if len(h.onDeleteH) != 1 {
+		t.Error("len(h.onDeleteH) != 1")
+	}
+	if len(h.onDeletedH) != 1 {
+		t.Error("len(h.onDeletedH) != 1")
+	}
+	if len(h.onClearH) != 1 {
+		t.Error("len(h.onClearH) != 1")
+	}
+	if len(h.onClearedH) != 1 {
+		t.Error("len(h.onClearedH) != 1")
+	}
+
+	ctx := context.Background()
+	ctxd := WithDisableHooks(ctx)
+
+	t.Run("onFind(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onFind(ctx, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onFind(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onFind(ctxd, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+	t.Run("onFound(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onFound(ctx, nil, nil, nil)
+
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onFound(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onFound(ctxd, nil, nil, nil)
+
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+
+	t.Run("onGet(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onGet(ctx, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onGet(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onGet(ctxd, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+	t.Run("onGot(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onGot(ctx, nil, nil)
+
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onGot(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onGot(ctxd, nil, nil)
+
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+
+	t.Run("onInsert(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onInsert(ctx, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onInsert(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onInsert(ctxd, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+	t.Run("onInserted(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onInserted(ctx, nil, nil)
+
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onInserted(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onInserted(ctxd, nil, nil)
+
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+
+	t.Run("onUpdate(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onUpdate(ctx, nil, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onUpdate(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onUpdate(ctxd, nil, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+	t.Run("onUpdated(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onUpdated(ctx, nil, nil, nil)
+
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onUpdated(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onUpdated(ctxd, nil, nil, nil)
+
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+
+	t.Run("onDelete(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onDelete(ctx, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onDelete(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onDelete(ctxd, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+	t.Run("onDeleted(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onDeleted(ctx, nil, nil)
+
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onDeleted(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onDeleted(ctxd, nil, nil)
+
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+
+	t.Run("onClear(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onClear(ctx, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onClear(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		if err := h.onClear(ctxd, nil); err != nil {
+			t.Error("calling hook resulted in error: ", err)
+		}
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
+	t.Run("onCleared(ctx,nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onCleared(ctx, nil, nil, nil)
+
+		if numCalled != 1 {
+			t.Errorf("expected numCalled == 1, got %d", numCalled)
+		}
+	})
+	t.Run("onCleared(WithDisableHooks(ctx),nil)", func(t *testing.T) {
+		numCalled = 0
+		h.onCleared(ctxd, nil, nil, nil)
+
+		if numCalled != 0 {
+			t.Errorf("expected numCalled == 0, got %d", numCalled)
+		}
+	})
 }

--- a/rest/method_item_delete.go
+++ b/rest/method_item_delete.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/rs/rest-layer/resource"
+
 	"github.com/rs/rest-layer/schema/query"
 )
 
@@ -14,7 +16,7 @@ func itemDelete(ctx context.Context, r *http.Request, route *RouteMatch) (status
 		return e.Code, nil, e
 	}
 	q.Window = &query.Window{Limit: 1}
-	l, err := route.Resource().Find(ctx, q)
+	l, err := route.Resource().Find(resource.WithDisableHooks(ctx), q)
 	if err != nil {
 		e = NewError(err)
 		return e.Code, nil, e

--- a/rest/method_item_get.go
+++ b/rest/method_item_get.go
@@ -15,6 +15,8 @@ func itemGet(ctx context.Context, r *http.Request, route *RouteMatch) (status in
 		return e.Code, nil, e
 	}
 	rsrc := route.Resource()
+	// FIXME: Calling Find in place of Get causes the resource package to
+	// run the OnFind/OnFound hooks over OnGet/OnGot!
 	q.Window = &query.Window{Limit: 1}
 	list, err := rsrc.Find(ctx, q)
 	if err != nil {

--- a/rest/method_item_patch.go
+++ b/rest/method_item_patch.go
@@ -24,7 +24,7 @@ func itemPatch(ctx context.Context, r *http.Request, route *RouteMatch) (status 
 	rsrc := route.Resource()
 	var original *resource.Item
 	q.Window = &query.Window{Limit: 1}
-	if l, err := rsrc.Find(ctx, q); err != nil {
+	if l, err := rsrc.Find(resource.WithDisableHooks(ctx), q); err != nil {
 		// If item can't be fetch, return an error.
 		e = NewError(err)
 		return e.Code, nil, e
@@ -37,7 +37,7 @@ func itemPatch(ctx context.Context, r *http.Request, route *RouteMatch) (status 
 	if err := checkIntegrityRequest(r, original); err != nil {
 		return err.Code, nil, err
 	}
-	changes, base := rsrc.Validator().Prepare(ctx, payload, &original.Payload, false)
+	changes, base := rsrc.Validator().Prepare(resource.WithDisableHooks(ctx), payload, &original.Payload, false)
 	// Append lookup fields to base payload so it isn't caught by ReadOnly
 	// (i.e.: contains id and parent resource refs if any).
 	for k, v := range route.ResourcePath.Values() {

--- a/rest/method_item_put.go
+++ b/rest/method_item_put.go
@@ -26,7 +26,7 @@ func itemPut(ctx context.Context, r *http.Request, route *RouteMatch) (status in
 	// manual id).
 	var original *resource.Item
 	q.Window = &query.Window{Limit: 1}
-	if l, err := rsrc.Find(ctx, q); err != nil && err != ErrNotFound {
+	if l, err := rsrc.Find(resource.WithDisableHooks(ctx), q); err != nil && err != ErrNotFound {
 		e = NewError(err)
 		return e.Code, nil, e
 	} else if len(l.Items) == 1 {
@@ -52,11 +52,11 @@ func itemPut(ctx context.Context, r *http.Request, route *RouteMatch) (status in
 	var base map[string]interface{}
 	if original == nil {
 		// PUT used to create a new document.
-		changes, base = rsrc.Validator().Prepare(ctx, payload, nil, false)
+		changes, base = rsrc.Validator().Prepare(resource.WithDisableHooks(ctx), payload, nil, false)
 		status = 201
 	} else {
 		// PUT used to replace an existing document.
-		changes, base = rsrc.Validator().Prepare(ctx, payload, &original.Payload, true)
+		changes, base = rsrc.Validator().Prepare(resource.WithDisableHooks(ctx), payload, &original.Payload, true)
 	}
 	// Append lookup fields to base payload so it isn't caught by ReadOnly
 	// (i.e.: contains id and parent resource refs if any).

--- a/rest/method_post.go
+++ b/rest/method_post.go
@@ -20,7 +20,7 @@ func listPost(ctx context.Context, r *http.Request, route *RouteMatch) (status i
 		return e.Code, nil, e
 	}
 	rsrc := route.Resource()
-	changes, base := rsrc.Validator().Prepare(ctx, payload, nil, false)
+	changes, base := rsrc.Validator().Prepare(resource.WithDisableHooks(ctx), payload, nil, false)
 	// Append lookup fields to base payload so it isn't caught by ReadOnly
 	// (i.e.: contains id and parent resource refs if any).
 	for k, v := range route.ResourcePath.Values() {


### PR DESCRIPTION
Fixes #171, and updates other intermediate calls to the resource package done by the rest package, so that they do not trigger unintended hooks.