### PR TITLE
Make query.Value a type alias of interface{}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7
+- 1.9
 - tip
 matrix:
   allow_failures:

--- a/resource/storage.go
+++ b/resource/storage.go
@@ -203,7 +203,7 @@ func (s storageWrapper) Find(ctx context.Context, q *query.Query) (list *ItemLis
 				// When query pattern is a list of documents request by their
 				// ids, use the multi get API.
 				if op.Field == "id" && (q.Window == nil || q.Window.Limit == len(op.Values)) {
-					return wrapMgetList(mg.MultiGet(ctx, valuesToInterface(op.Values)))
+					return wrapMgetList(mg.MultiGet(ctx, op.Values))
 				}
 			}
 		}

--- a/resource/util.go
+++ b/resource/util.go
@@ -4,8 +4,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-
-	"github.com/rs/rest-layer/schema/query"
 )
 
 // Etag computes an etag based on containt of the payload.
@@ -15,12 +13,4 @@ func genEtag(payload map[string]interface{}) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%x", md5.Sum(b)), nil
-}
-
-func valuesToInterface(v []query.Value) []interface{} {
-	I := make([]interface{}, len(v))
-	for i, _v := range v {
-		I[i] = _v
-	}
-	return I
 }

--- a/schema/query/predicate.go
+++ b/schema/query/predicate.go
@@ -65,7 +65,7 @@ type Expression interface {
 }
 
 // Value represents any kind of value to use in query.
-type Value interface{}
+type Value = interface{}
 
 // And joins query clauses with a logical AND, returns all documents that match
 // the conditions of both clauses.


### PR DESCRIPTION
This fixes the case where filtering for dictionary keys or arrays fails due to a mismatch of types as described in https://github.com/rs/rest-layer/issues/139 and https://github.com/rs/rest-layer/issues/176.