### PR TITLE
Array support for index lookup (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Until version 1.0 of rest-layer, breaking changes may occur at any time if you r
 
 Below is an overview over recent breaking changes, starting from an arbitrary point with PR #151:
 
-- PR #151: `ValuesValidator FieldValidator` attribute in the `scheam.Dict` struct replaced by `Values Field`.
+- PR #151: `ValuesValidator FieldValidator` attribute in `schema.Dict` struct replaced by `Values Field`.
+- PR #179: `ValuesValidator FieldValidator` attribute in `schema.Array` struct replaced by `Values Field`.
 
 From the next release and onwards (0.2), this list will summarize breaking changes done to master since the last release.
 
@@ -391,7 +392,7 @@ Vary: Origin
     "id": "ar6ejs6kj5lflgc28es0",
     "created": "2015-07-27T21:46:55.355857401+02:00",
     "updated": "2015-07-27T21:46:55.355857989+02:00",
-	"title": "My first post",
+    "title": "My first post",
     "user": "ar6ejgmkj5lfl98r67p0"
 }
 ```
@@ -434,7 +435,7 @@ X-Total: 1
         "_etag": "307ae92df6c3dd54847bfc7d72422e07",
         "created": "2015-07-27T21:46:55.355857401+02:00",
         "updated": "2015-07-27T21:46:55.355857989+02:00",
-		"title": "My first post",
+        "title": "My first post",
         "user": "ar6ejgmkj5lfl98r67p0"
     }
 ]
@@ -459,7 +460,7 @@ X-Total: 1
         "_etag": "307ae92df6c3dd54847bfc7d72422e07",
         "created": "2015-07-27T21:46:55.355857401+02:00",
         "updated": "2015-07-27T21:46:55.355857989+02:00",
-		"title": "My first post",
+        "title": "My first post",
         "user": {
             "id": "ar6ejgmkj5lfl98r67p0",
             "name": "John Doe"
@@ -491,11 +492,11 @@ Vary: Origin
         "posts": [
             {
                 "id": "ar6ejs6kj5lflgc28es0",
-				"title": "My first post"
+                "title": "My first post"
             },
             {
                 "id": "ar6ek26kj5lfljgh84qg",
-				"title": "My second post"
+                "title": "My second post"
             }
         ]
     }
@@ -516,7 +517,7 @@ Sample resource schema:
 
 ```go
 foo = schema.Schema{
-	Description: "A foo object",
+    Description: "A foo object",
     Fields: schema.Fields{
         "field_name": {
             Required: true,
@@ -667,7 +668,7 @@ The `resource.Conf` type has the following customizable properties:
 | ------------------------ | -------------
 | `AllowedModes`           | A list of `resource.Mode` allowed for the resource.
 | `PaginationDefaultLimit` | If set, pagination is enabled by default with a number of item per page defined here.
-| `ForceTotal`			   | Control the behavior of the computation of `X-Total` header and the `total` query-string parameter. See `resource.ForceTotalMode` for available options.
+| `ForceTotal`             | Control the behavior of the computation of `X-Total` header and the `total` query-string parameter. See `resource.ForceTotalMode` for available options.
 
 ### Modes
 
@@ -772,10 +773,8 @@ Here we would get all post with their respective 5 last comments embedded in the
                 },
                 "message": "Last comment"
             },
-            ...
         ]
     },
-    ...
 ]
 ```
 

--- a/rest/method_post_test.go
+++ b/rest/method_post_test.go
@@ -285,7 +285,7 @@ func TestHandlerPostList(t *testing.T) {
 				index.Bind("bar", schema.Schema{Fields: schema.Fields{
 					"id": {},
 					"foos": {Validator: &schema.Array{
-						ValuesValidator: &schema.Reference{Path: "foo"},
+						Values: schema.Field{Validator: &schema.Reference{Path: "foo"}},
 					}},
 				}}, s, resource.DefaultConf)
 				return &requestTestVars{Index: index}
@@ -312,7 +312,7 @@ func TestHandlerPostList(t *testing.T) {
 				index.Bind("bar", schema.Schema{Fields: schema.Fields{
 					"id": {},
 					"foos": {Validator: &schema.Array{
-						ValuesValidator: &schema.Reference{Path: "foo"},
+						Values: schema.Field{Validator: &schema.Reference{Path: "foo"}},
 					}},
 				}}, s, resource.DefaultConf)
 				return &requestTestVars{Index: index}

--- a/schema/array_test.go
+++ b/schema/array_test.go
@@ -11,13 +11,13 @@ import (
 func TestArrayValidatorCompile(t *testing.T) {
 	testCases := []referenceCompilerTestCase{
 		{
-			Name:             "ValuesValidator=&String{}",
-			Compiler:         &schema.Array{ValuesValidator: &schema.String{}},
+			Name:             "Values.Validator=&String{}",
+			Compiler:         &schema.Array{Values: schema.Field{Validator: &schema.String{}}},
 			ReferenceChecker: fakeReferenceChecker{},
 		},
 		{
-			Name:             "ValuesValidator=&String{Regexp:invalid}",
-			Compiler:         &schema.Array{ValuesValidator: &schema.String{Regexp: "[invalid re"}},
+			Name:             "Values.Validator=&String{Regexp:invalid}",
+			Compiler:         &schema.Array{Values: schema.Field{Validator: &schema.String{Regexp: "[invalid re"}}},
 			ReferenceChecker: fakeReferenceChecker{},
 			Error:            "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`",
 		},
@@ -30,50 +30,50 @@ func TestArrayValidatorCompile(t *testing.T) {
 func TestArrayValidator(t *testing.T) {
 	testCases := []fieldValidatorTestCase{
 		{
-			Name:      `ValuesValidator=nil,Validate([]interface{}{true,"value"})`,
+			Name:      `Values.Validator=nil,Validate([]interface{}{true,"value"})`,
 			Validator: &schema.Array{},
 			Input:     []interface{}{true, "value"},
 			Expect:    []interface{}{true, "value"},
 		},
 		{
-			Name:      `ValuesValidator=&schema.Bool{},Validate([]interface{}{true,false})`,
-			Validator: &schema.Array{ValuesValidator: &schema.Bool{}},
+			Name:      `Values.Validator=&schema.Bool{},Validate([]interface{}{true,false})`,
+			Validator: &schema.Array{Values: schema.Field{Validator: &schema.Bool{}}},
 			Input:     []interface{}{true, false},
 			Expect:    []interface{}{true, false},
 		},
 		{
-			Name:      `ValuesValidator=&schema.Bool{},Validate([]interface{}{true,"value"})`,
-			Validator: &schema.Array{ValuesValidator: &schema.Bool{}},
+			Name:      `Values.Validator=&schema.Bool{},Validate([]interface{}{true,"value"})`,
+			Validator: &schema.Array{Values: schema.Field{Validator: &schema.Bool{}}},
 			Input:     []interface{}{true, "value"},
 			Error:     "invalid value at #2: not a Boolean",
 		},
 		{
-			Name:      `ValuesValidator=&String{},Validate("value")`,
-			Validator: &schema.Array{ValuesValidator: &schema.String{}},
+			Name:      `Values.Validator=&String{},Validate("value")`,
+			Validator: &schema.Array{Values: schema.Field{Validator: &schema.String{}}},
 			Input:     "value",
 			Error:     "not an array",
 		},
 		{
 			Name:      `MinLen=2,Validate([]interface{}{true,false})`,
-			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MinLen: 2},
+			Validator: &schema.Array{Values: schema.Field{Validator: &schema.Bool{}}, MinLen: 2},
 			Input:     []interface{}{true, false},
 			Expect:    []interface{}{true, false},
 		},
 		{
 			Name:      `MinLen=3,Validate([]interface{}{true,false})`,
-			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MinLen: 3},
+			Validator: &schema.Array{Values: schema.Field{Validator: &schema.Bool{}}, MinLen: 3},
 			Input:     []interface{}{true, false},
 			Error:     "has fewer items than 3",
 		},
 		{
 			Name:      `MaxLen=2,Validate([]interface{}{true,false})`,
-			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MaxLen: 2},
+			Validator: &schema.Array{Values: schema.Field{Validator: &schema.Bool{}}, MaxLen: 2},
 			Input:     []interface{}{true, false},
 			Expect:    []interface{}{true, false},
 		},
 		{
 			Name:      `MaxLen=1,Validate([]interface{}{true,false})`,
-			Validator: &schema.Array{ValuesValidator: &schema.Bool{}, MaxLen: 1},
+			Validator: &schema.Array{Values: schema.Field{Validator: &schema.Bool{}}, MaxLen: 1},
 			Input:     []interface{}{true, false},
 			Error:     "has more items than 1",
 		},

--- a/schema/encoding/jsonschema/all_test.go
+++ b/schema/encoding/jsonschema/all_test.go
@@ -295,7 +295,9 @@ func TestEncoder(t *testing.T) {
 				Fields: schema.Fields{
 					"students": {
 						Validator: &schema.Array{
-							ValuesValidator: &schema.Object{},
+							Values: schema.Field{
+								Validator: &schema.Object{},
+							},
 						},
 					},
 				},

--- a/schema/encoding/jsonschema/array.go
+++ b/schema/encoding/jsonschema/array.go
@@ -14,16 +14,25 @@ func (v arrayBuilder) BuildJSONSchema() (map[string]interface{}, error) {
 	if v.MaxLen > 0 {
 		m["maxItems"] = v.MaxLen
 	}
-	if v.ValuesValidator != nil {
-		builder, err := ValidatorBuilder(v.ValuesValidator)
+
+	// Retrieve values validator JSON schema.
+	var valuesSchema map[string]interface{}
+	if v.Values.Validator != nil {
+		b, err := ValidatorBuilder(v.Values.Validator)
 		if err != nil {
 			return nil, err
 		}
-		items, err := builder.BuildJSONSchema()
+		valuesSchema, err = b.BuildJSONSchema()
 		if err != nil {
 			return nil, err
 		}
-		m["items"] = items
+	} else {
+		valuesSchema = map[string]interface{}{}
 	}
+	addFieldProperties(valuesSchema, v.Values)
+	if len(valuesSchema) > 0 {
+		m["items"] = valuesSchema
+	}
+
 	return m, nil
 }

--- a/schema/encoding/jsonschema/array_test.go
+++ b/schema/encoding/jsonschema/array_test.go
@@ -11,7 +11,7 @@ import (
 func TestArray(t *testing.T) {
 	testCases := []encoderTestCase{
 		{
-			name: "ValuesValidator=nil",
+			name: "Values.Validator=nil",
 			schema: schema.Schema{
 				Fields: schema.Fields{
 					"a": schema.Field{
@@ -22,11 +22,13 @@ func TestArray(t *testing.T) {
 			customValidate: fieldValidator("a", `{"type": "array"}`),
 		},
 		{
-			name: "ValuesValidator=&schema.Bool{}",
+			name: "Values.Validator=&schema.Bool{}",
 			schema: schema.Schema{
 				Fields: schema.Fields{
 					"a": schema.Field{
-						Validator: &schema.Array{ValuesValidator: &schema.Bool{}},
+						Validator: &schema.Array{Values: schema.Field{
+							Validator: &schema.Bool{},
+						}},
 					},
 				},
 			},

--- a/schema/encoding/jsonschema/benchmark_test.go
+++ b/schema/encoding/jsonschema/benchmark_test.go
@@ -99,7 +99,9 @@ func complexSchema1() schema.Schema {
 			"m": schema.Field{
 				Description: "m",
 				Validator: &schema.Array{
-					ValuesValidator: &schema.Object{Schema: mSchema},
+					Values: schema.Field{
+						Validator: &schema.Object{Schema: mSchema},
+					},
 				},
 			},
 		},
@@ -177,8 +179,8 @@ func complexSchema2() schema.Schema {
 				Description: "c",
 				Required:    true,
 				Validator: &schema.Array{
-					ValuesValidator: &schema.Object{
-						Schema: cSchema,
+					Values: schema.Field{
+						Validator: &schema.Object{Schema: cSchema},
 					},
 				},
 			},
@@ -186,8 +188,8 @@ func complexSchema2() schema.Schema {
 				Description: "d",
 				Required:    true,
 				Validator: &schema.Array{
-					ValuesValidator: &schema.Object{
-						Schema: dSchema,
+					Values: schema.Field{
+						Validator: &schema.Object{Schema: dSchema},
 					},
 				},
 			},

--- a/schema/encoding/jsonschema/testutil_test.go
+++ b/schema/encoding/jsonschema/testutil_test.go
@@ -123,8 +123,8 @@ var (
 			"students": {
 				Description: "Array of students",
 				Validator: &schema.Array{
-					ValuesValidator: &schema.Object{
-						Schema: &simpleSchema,
+					Values: schema.Field{
+						Validator: &schema.Object{Schema: &simpleSchema},
 					},
 				},
 			},


### PR DESCRIPTION
This commit adds support for looking up field definitions inside
schema.Array instances. To achieve this, Array.ValuesValidator has been
deprecated in favour of a new Array.Values property that holds a full
schema.Field.

As a result, it should be possible to filter on schema.Array index value
in backends that supports it.


TODO:
- [x] Implement changes 
- [x] Verify against MongoDB backend
- [x] Update README