### PR TITLE
Use first matching serializer when serializing a field with AnyOf

### DIFF
--- a/schema/all_test.go
+++ b/schema/all_test.go
@@ -56,6 +56,34 @@ func (tc fieldValidatorTestCase) Run(t *testing.T) {
 	})
 }
 
+type fieldSerializerTestCase struct {
+	Name             string
+	Serializer       schema.FieldSerializer
+	ReferenceChecker schema.ReferenceChecker
+	Input, Expect    interface{}
+	Error            string
+}
+
+func (tc fieldSerializerTestCase) Run(t *testing.T) {
+	t.Run(tc.Name, func(t *testing.T) {
+		t.Parallel()
+
+		if cmp, ok := tc.Serializer.(schema.Compiler); ok {
+			err := cmp.Compile(tc.ReferenceChecker)
+			assert.NoError(t, err, "Validator.Compile(%v)", tc.ReferenceChecker)
+		}
+
+		s, err := tc.Serializer.Serialize(tc.Input)
+		if tc.Error == "" {
+			assert.NoError(t, err, "Serializer.Serialize(%v)", tc.Input)
+			assert.Equal(t, tc.Expect, s, "Serializer.Serialize(%v)", tc.Input)
+		} else {
+			assert.EqualError(t, err, tc.Error, "Serializer.Serialize(%v)", tc.Input)
+			assert.Nil(t, s, "Serializer.Serialize(%v)", tc.Input)
+		}
+	})
+}
+
 type fakeReferenceChecker map[string]struct {
 	IDs       []interface{}
 	Validator schema.FieldValidator

--- a/schema/all_test.go
+++ b/schema/all_test.go
@@ -2,10 +2,10 @@ package schema_test
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/rs/rest-layer/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 type referenceCompilerTestCase struct {
@@ -21,9 +21,13 @@ func (tc referenceCompilerTestCase) Run(t *testing.T) {
 
 		err := tc.Compiler.Compile(tc.ReferenceChecker)
 		if tc.Error == "" {
-			assert.NoError(t, err, "Compiler.Compile(%v)", tc.ReferenceChecker)
+			if err != nil {
+				t.Errorf("Compiler.Compile(%v): unexpected error: %v", tc.ReferenceChecker, err)
+			}
 		} else {
-			assert.EqualError(t, err, tc.Error, "Compiler.Compile(%v)", tc.ReferenceChecker)
+			if err == nil || err.Error() != tc.Error {
+				t.Errorf("Compiler.Compile(%v): expected error: %v, got: %v", tc.ReferenceChecker, tc.Error, err)
+			}
 		}
 	})
 }
@@ -42,16 +46,26 @@ func (tc fieldValidatorTestCase) Run(t *testing.T) {
 
 		if cmp, ok := tc.Validator.(schema.Compiler); ok {
 			err := cmp.Compile(tc.ReferenceChecker)
-			assert.NoError(t, err, "Validator.Compile(%v)", tc.ReferenceChecker)
+			if err != nil {
+				t.Errorf("Validator.Compile(%v): unexpected error: %v", tc.ReferenceChecker, err)
+			}
 		}
 
 		v, err := tc.Validator.Validate(tc.Input)
 		if tc.Error == "" {
-			assert.NoError(t, err, "Validator.Validate(%v)", tc.Input)
-			assert.Equal(t, tc.Expect, v, "Validator.Validate(%v)", tc.Input)
+			if err != nil {
+				t.Errorf("Validator.Validate(%v): unexpected error: %v", tc.ReferenceChecker, err)
+			}
+			if !reflect.DeepEqual(v, tc.Expect) {
+				t.Errorf("Validator.Validate(%v): expected: %v, got: %v", tc.Input, tc.Expect, v)
+			}
 		} else {
-			assert.EqualError(t, err, tc.Error, "Validator.Validate(%v)", tc.Input)
-			assert.Nil(t, v, "Validator.Validate(%v)", tc.Input)
+			if err == nil || err.Error() != tc.Error {
+				t.Errorf("Validator.Validate(%v): expected error: %v, got: %v", tc.ReferenceChecker, tc.Error, err)
+			}
+			if v != nil {
+				t.Errorf("Validator.Validate(%v): expected: nil, got: %v", tc.Input, v)
+			}
 		}
 	})
 }
@@ -70,16 +84,26 @@ func (tc fieldSerializerTestCase) Run(t *testing.T) {
 
 		if cmp, ok := tc.Serializer.(schema.Compiler); ok {
 			err := cmp.Compile(tc.ReferenceChecker)
-			assert.NoError(t, err, "Validator.Compile(%v)", tc.ReferenceChecker)
+			if err != nil {
+				t.Errorf("Validator.Compile(%v): unexpected error: %v", tc.ReferenceChecker, err)
+			}
 		}
 
 		s, err := tc.Serializer.Serialize(tc.Input)
 		if tc.Error == "" {
-			assert.NoError(t, err, "Serializer.Serialize(%v)", tc.Input)
-			assert.Equal(t, tc.Expect, s, "Serializer.Serialize(%v)", tc.Input)
+			if err != nil {
+				t.Errorf("Serializer.Serialize(%v): unexpected error: %v", tc.ReferenceChecker, err)
+			}
+			if s != tc.Expect {
+				t.Errorf("Serializer.Serialize(%v): expected: %v, got: %v", tc.Input, tc.Expect, s)
+			}
 		} else {
-			assert.EqualError(t, err, tc.Error, "Serializer.Serialize(%v)", tc.Input)
-			assert.Nil(t, s, "Serializer.Serialize(%v)", tc.Input)
+			if err == nil || err.Error() != tc.Error {
+				t.Errorf("Serializer.Serialize(%v): expected error: %v, got: %v", tc.ReferenceChecker, tc.Error, err)
+			}
+			if s != nil {
+				t.Errorf("Serializer.Serialize(%v): expected: nil, got: %v", tc.Input, s)
+			}
 		}
 	})
 }

--- a/schema/anyof.go
+++ b/schema/anyof.go
@@ -2,7 +2,9 @@ package schema
 
 import "errors"
 
-// AnyOf validates if any of the sub field validators validates.
+// AnyOf validates if any of the sub field validators validates. If any of the
+// sub field validators implements the FieldSerializer interface, the *first*
+// implementation which does not error will be used.
 type AnyOf []FieldValidator
 
 // Compile implements the Compiler interface.
@@ -27,4 +29,24 @@ func (v AnyOf) Validate(value interface{}) (interface{}, error) {
 	}
 	// TODO: combine errors.
 	return nil, errors.New("invalid")
+}
+
+// Serialize attempts to serialize the value using the first available
+// FieldSerializer which does not return an error. If no appropriate serializer
+// is found, the input value is returned.
+func (v AnyOf) Serialize(value interface{}) (interface{}, error) {
+	for _, serializer := range v {
+		s, ok := serializer.(FieldSerializer)
+		if !ok {
+			continue
+		}
+
+		v, err := s.Serialize(value)
+		if err != nil {
+			continue
+		}
+		return v, nil
+	}
+
+	return value, nil
 }

--- a/schema/anyof_test.go
+++ b/schema/anyof_test.go
@@ -1,10 +1,37 @@
 package schema_test
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/rs/rest-layer/schema"
 )
+
+// hexByteArray implements the FieldSerializer interface.
+type hexByteArray struct{}
+
+// Validate is a dummy implemetation of the FieldValidator interface implemented
+// to allow inclusion in AnyOf.
+func (h hexByteArray) Validate(value interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (h hexByteArray) Serialize(value interface{}) (interface{}, error) {
+	switch t := value.(type) {
+	case []byte:
+		if len(t) == 0 {
+			return "", nil
+		}
+		res := "0x"
+		for _, v := range t {
+			res += fmt.Sprintf("%x", v)
+		}
+		return res, nil
+	default:
+		return nil, errors.New("invalid type")
+	}
+}
 
 func TestAnyOfCompile(t *testing.T) {
 	cases := []referenceCompilerTestCase{
@@ -80,6 +107,52 @@ func TestAnyOfValidate(t *testing.T) {
 			},
 			Input:  "foo1",
 			Expect: "foo1",
+		},
+	}
+	for i := range cases {
+		cases[i].Run(t)
+	}
+}
+
+func TestAnyOfSerialize(t *testing.T) {
+	cases := []fieldSerializerTestCase{
+		{
+			Name:       "{Bool,Bool}.Serialize(true)",
+			Serializer: schema.AnyOf{&schema.Bool{}, &schema.Bool{}},
+			Input:      true,
+			Expect:     true,
+		},
+		{
+			Name:       `{Bool,IP}.Serialize("1.2.3.4")`,
+			Serializer: schema.AnyOf{&schema.Bool{}, &schema.IP{}},
+			Input:      "1.2.3.4",
+			Expect:     "1.2.3.4",
+		},
+		{
+			Name:       `{Bool,IP{StoreBinary:true}}.Serialize("1.2.3.4")`,
+			Serializer: schema.AnyOf{&schema.Bool{}, &schema.IP{StoreBinary: true}},
+			Input:      []byte{1, 2, 3, 4},
+			Expect:     "1.2.3.4",
+		},
+		{
+			Name:       `{hexByteArray,IP{StoreBinary:true}}.Serialize([]byte{1,2,3,4})`,
+			Serializer: schema.AnyOf{&hexByteArray{}, &schema.IP{StoreBinary: true}},
+			Input:      []byte{1, 2, 3, 4},
+			Expect:     "0x1234",
+		},
+		{
+			Name:       `{IP{StoreBinary:true},hexByteArray}.Serialize([]byte{1,2,3,4})`,
+			Serializer: schema.AnyOf{&schema.IP{StoreBinary: true}, &hexByteArray{}},
+			Input:      []byte{1, 2, 3, 4},
+			Expect:     "1.2.3.4",
+		},
+		// IP.Serialize() returns an error if the input is not a 4 or 16 byte
+		// array, so hexByteArray.Serialize() should run.
+		{
+			Name:       `{IP{StoreBinary:true},hexByteArray}.Serialize([]byte{1,2,3,4,5})`,
+			Serializer: schema.AnyOf{&schema.IP{StoreBinary: true}, &hexByteArray{}},
+			Input:      []byte{1, 2, 3, 4, 5},
+			Expect:     "0x12345",
 		},
 	}
 	for i := range cases {


### PR DESCRIPTION
This PR adds support for calling FieldSerializer on AnyOf members as proposed in #182.

I added a check for the existence of `Serializer` in the test runner to prevent having to add the `Serializer` to every existing test. 