### PR TITLE
Predicate operators

### DIFF
--- a/schema/query/predicate.go
+++ b/schema/query/predicate.go
@@ -140,11 +140,27 @@ type In struct {
 // Match implements Expression interface.
 func (e In) Match(payload map[string]interface{}) bool {
 	value := getField(payload, e.Field)
-	for _, v := range e.Values {
-		if reflect.DeepEqual(v, value) {
-			return true
+
+	// The $in operator in MongoDB allows matching both single values and an
+	// array of values.
+	// https://docs.mongodb.com/manual/reference/operator/query/in/
+	switch vt := value.(type) {
+	case []interface{}:
+		for _, v := range e.Values {
+			for _, vv := range vt {
+				if reflect.DeepEqual(v, vv) {
+					return true
+				}
+			}
+		}
+	default:
+		for _, v := range e.Values {
+			if reflect.DeepEqual(v, value) {
+				return true
+			}
 		}
 	}
+
 	return false
 }
 
@@ -171,9 +187,24 @@ type NotIn struct {
 // Match implements Expression interface.
 func (e NotIn) Match(payload map[string]interface{}) bool {
 	value := getField(payload, e.Field)
-	for _, v := range e.Values {
-		if reflect.DeepEqual(v, value) {
-			return false
+
+	// The $nin operator in MongoDB allows matching both single values and an
+	// array of values.
+	// https://docs.mongodb.com/manual/reference/operator/query/nin/
+	switch vt := value.(type) {
+	case []interface{}:
+		for _, v := range e.Values {
+			for _, vv := range vt {
+				if reflect.DeepEqual(v, vv) {
+					return false
+				}
+			}
+		}
+	default:
+		for _, v := range e.Values {
+			if reflect.DeepEqual(v, value) {
+				return false
+			}
 		}
 	}
 	return true

--- a/schema/query/predicate_test.go
+++ b/schema/query/predicate_test.go
@@ -106,6 +106,12 @@ func TestMatch(t *testing.T) {
 				{map[string]interface{}{"bar": float64(1)}, false},
 			},
 		},
+		{
+			`{"foo.bar": "baz"}`, []test{
+				{map[string]interface{}{"foo": map[string]interface{}{"bar": "baz"}}, true},
+				{map[string]interface{}{"foo": map[string]interface{}{"bar": "bar"}}, false},
+			},
+		},
 	}
 	for i := range tests {
 		tt := tests[i]
@@ -143,6 +149,7 @@ func TestString(t *testing.T) {
 		`{"$and": [{"foo": "bar"}, {"foo": "baz"}]}`:              `{$and: [{foo: "bar"}, {foo: "baz"}]}`,
 		`{"foo": "bar", "$or": [{"bar": "baz"}, {"bar": "foo"}]}`: `{foo: "bar", $or: [{bar: "baz"}, {bar: "foo"}]}`,
 		`{"foo": ["bar", "baz"]}`:                                 `{foo: ["bar","baz"]}`,
+		`{"foo.bar": "baz"}`:                                      `{foo.bar: "baz"}`,
 	}
 	for query, want := range tests {
 		q, err := ParsePredicate(query)

--- a/schema/query/predicate_test.go
+++ b/schema/query/predicate_test.go
@@ -69,9 +69,21 @@ func TestMatch(t *testing.T) {
 			},
 		},
 		{
+			`{"foo": {"$in": ["baz"]}}`, []test{
+				{map[string]interface{}{"foo": []interface{}{"baz"}}, true},
+				{map[string]interface{}{"foo": []interface{}{"bar"}}, false},
+			},
+		},
+		{
 			`{"foo": {"$nin": ["bar", "baz"]}}`, []test{
 				{map[string]interface{}{"foo": "bar"}, false},
 				{map[string]interface{}{"foo": "foo"}, true},
+			},
+		},
+		{
+			`{"foo": {"$nin": ["baz"]}}`, []test{
+				{map[string]interface{}{"foo": []interface{}{"baz"}}, false},
+				{map[string]interface{}{"foo": []interface{}{"bar"}}, true},
 			},
 		},
 		{

--- a/schema/query/utils_test.go
+++ b/schema/query/utils_test.go
@@ -34,3 +34,23 @@ func TestIsNumber(t *testing.T) {
 		})
 	}
 }
+
+func TestGetField(t *testing.T) {
+	cases := []struct {
+		name      string
+		payload   map[string]interface{}
+		fieldName string
+		want      string
+	}{
+		{"foo", map[string]interface{}{"foo": "bar"}, "foo", "bar"},
+		{"foo.bar", map[string]interface{}{"foo": map[string]interface{}{"bar": "baz"}}, "foo.bar", "baz"},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			if res := getField(tc.payload, tc.fieldName); res != tc.want {
+				t.Errorf("field = %v, wanted %v", res, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This add support for using the $in and $nin operators in the query package against array fields as described in https://github.com/rs/rest-layer/issues/187.

It also adds tests for nested fields and the `utils.getField` function.

 