### PR TITLE
resolve resource constructor function shadowing builtin new function

### DIFF
--- a/resource/index.go
+++ b/resource/index.go
@@ -48,7 +48,7 @@ func NewIndex() Index {
 // Bind a resource at the specified endpoint name.
 func (i *index) Bind(name string, s schema.Schema, h Storer, c Conf) *Resource {
 	assertNotBound(name, i.resources, nil)
-	sr := new(name, s, h, c)
+	sr := newResource(name, s, h, c)
 	i.resources.add(sr)
 	return sr
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -67,8 +67,8 @@ func (v validatorFallback) GetField(name string) *schema.Field {
 	return v.fallback.GetField(name)
 }
 
-// new creates a new resource with provided spec, handler and config.
-func new(name string, s schema.Schema, h Storer, c Conf) *Resource {
+// newResource creates a new resource with provided spec, handler and config.
+func newResource(name string, s schema.Schema, h Storer, c Conf) *Resource {
 	return &Resource{
 		name:   name,
 		path:   name,
@@ -136,7 +136,7 @@ func (r *Resource) Bind(name, field string, s schema.Schema, h Storer, c Conf) *
 	if f := s.GetField(field); f == nil {
 		logPanicf(nil, "Cannot bind `%s' as sub-resource: field `%s' does not exist in the sub-resource'", name, field)
 	}
-	sr := new(name, s, h, c)
+	sr := newResource(name, s, h, c)
 	sr.parentField = field
 	sr.path = r.path + "." + name
 	r.resources.add(sr)

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -97,7 +97,7 @@ func TestSubResources(t *testing.T) {
 }
 
 func TestResourceBindDupViaAlias(t *testing.T) {
-	r := new("name", schema.Schema{Fields: schema.Fields{"f": {}}}, nil, DefaultConf)
+	r := newResource("name", schema.Schema{Fields: schema.Fields{"f": {}}}, nil, DefaultConf)
 	r.Alias("foo", url.Values{})
 	log.SetOutput(ioutil.Discard)
 	assert.Panics(t, func() {
@@ -106,7 +106,7 @@ func TestResourceBindDupViaAlias(t *testing.T) {
 }
 
 func TestResourceBindOnMissingField(t *testing.T) {
-	r := new("name", schema.Schema{Fields: schema.Fields{"f": {}}}, nil, DefaultConf)
+	r := newResource("name", schema.Schema{Fields: schema.Fields{"f": {}}}, nil, DefaultConf)
 	log.SetOutput(ioutil.Discard)
 	assert.Panics(t, func() {
 		r.Bind("foo", "m", schema.Schema{Fields: schema.Fields{"f": {}}}, nil, DefaultConf)


### PR DESCRIPTION
The constructor function used to create a new instance of the resource should not have the same name as the builtin function. The code still compiles and functions normally, it's just not nice :)