### PR TITLE
Migrate to Jekyll for documentation

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+rest-layer.io

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+remote_theme: rs/gh-readme


### PR DESCRIPTION
I ported rest-layer.io theme as a Jekyll Github Page template. This way,
the documentation can be automatically generated from the README without
manual intervention.