### PR TITLE
Allow single expression in AND/OR queries

### DIFF
--- a/schema/query/predicate_parser.go
+++ b/schema/query/predicate_parser.go
@@ -97,8 +97,8 @@ func (p *predicateParser) parseExpression() (Expression, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", label, err)
 		}
-		if len(subExp) < 2 {
-			return nil, fmt.Errorf("%s: two expressions or more required", label)
+		if len(subExp) < 1 {
+			return nil, fmt.Errorf("%s: one expressions or more required", label)
 		}
 		if label == opAnd {
 			and := And(subExp)

--- a/schema/query/predicate_parser_test.go
+++ b/schema/query/predicate_parser_test.go
@@ -288,22 +288,12 @@ func TestParse(t *testing.T) {
 		{
 			`{"$or": []}`,
 			Predicate{},
-			errors.New("char 10: $or: two expressions or more required"),
-		},
-		{
-			`{"$or": [{"foo": "bar"}]}`,
-			Predicate{},
-			errors.New("char 24: $or: two expressions or more required"),
+			errors.New("char 10: $or: one expressions or more required"),
 		},
 		{
 			`{"$and": "foo"}`,
 			Predicate{},
 			errors.New("char 9: $and: expected '[' got '\"'"),
-		},
-		{
-			`{"$and": [{"foo": "bar"}]}`,
-			Predicate{},
-			errors.New("char 25: $and: two expressions or more required"),
 		},
 		{
 			`{"$and": ["foo", "bar"]}`,


### PR DESCRIPTION
Allowing single expressions in AND / OR queries allows for less special casing in the clients. 