### PR TITLE
add support for int64

### DIFF
--- a/schema/integer.go
+++ b/schema/integer.go
@@ -22,11 +22,15 @@ func (v Integer) parse(value interface{}) (interface{}, error) {
 			value = v
 		}
 	}
-	i, ok := value.(int)
-	if !ok {
-		return nil, errors.New("not an integer")
+
+	if i, ok := value.(int); ok {
+		return i, nil
 	}
-	return i, nil
+	if i, ok := value.(int64); ok {
+		return i, nil
+	}
+
+	return nil, errors.New("not an integer")
 }
 
 // ValidateQuery implements schema.FieldQueryValidator interface
@@ -35,11 +39,15 @@ func (v Integer) ValidateQuery(value interface{}) (interface{}, error) {
 }
 
 func (v Integer) get(value interface{}) (int, error) {
-	i, ok := value.(int)
-	if !ok {
-		return 0, errors.New("not an integer")
+	if i, ok := value.(int); ok {
+		return int(i), nil
 	}
-	return i, nil
+
+	if i, ok := value.(int64); ok {
+		return int(i), nil
+	}
+
+	return 0, errors.New("not an integer")
 }
 
 // Validate validates and normalize integer based value.


### PR DESCRIPTION
Integer fields fails on PATCH when Storage backend used int64 instead of int, like postgres. This PR fix that issue.

Without this patch;

```
$ http -b POST :8080/assets type=ipv4 value=1.1.1.1
{
    "created": "2019-01-08T23:26:12.170595+01:00",
    "cvss": "CVSS:3.0/CR:X/IR:X/AR:X/MAV:X/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X",
    "id": "bgqi713mvbapu22t9l10",
    "source": "undefined",
    "ttl": 0,
    "type": "ipv4",
    "updated": "2019-01-08T23:26:12.170595+01:00",
    "value": "1.1.1.1"
}

$ http -b PATCH :8080/assets/bgqi713mvbapu22t9l10 type=ipv4 value=1.1.1.2
{
    "code": 422,
    "issues": {
        "ttl": [
            "not an integer"
        ]
    },
    "message": "Document contains error(s)"
}
```

With this patch;

```
$ http -b POST :8080/assets type=ipv4 value=1.1.1.1
{
    "created": "2019-01-09T01:34:10.530449+01:00",
    "cvss": "CVSS:3.0/CR:X/IR:X/AR:X/MAV:X/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X",
    "id": "bgqk30jmvbaq3h9fqqb0",
    "source": "undefined",
    "ttl": 0,
    "type": "ipv4",
    "updated": "2019-01-09T01:34:10.530448+01:00",
    "value": "1.1.1.1"
}

$ http -b PATCH :8080/assets/bgqk30jmvbaq3h9fqqb0 type=ipv4 value=1.1.1.2
{
    "created": "2019-01-09T01:34:10.530449Z",
    "cvss": "CVSS:3.0/CR:X/IR:X/AR:X/MAV:X/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X",
    "id": "bgqk30jmvbaq3h9fqqb0",
    "source": "undefined",
    "ttl": 0,
    "type": "ipv4",
    "updated": "2019-01-09T01:34:45.43442+01:00",
    "value": "1.1.1.2"
}
```
