### PR TITLE
Fix fields projections on nested sub-resources. Adds validation on fi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Below is an overview over recent breaking changes, starting from an arbitrary po
   - Storage drivers need to accept pointer to `Expression` implementer in `query.Predicate`.
   - `filter` parameters in sub-query will be validated for type match.
   - `filter` parameters will be validated for type match only, instead of type & constrains.
+- PR #228: `Reference` projection fields will be validated against referenced resource schema.
+- PR #230: `Connection` projection fields will be validated against connected resource schema.
 
 From the next release and onwards (0.2), this list will summarize breaking changes done to master since the last release.
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -145,7 +145,7 @@ func (r *Resource) Bind(name, field string, s schema.Schema, h Storer, c Conf) *
 		Validator: &schema.Connection{
 			Path:      "." + name,
 			Field:     field,
-			Validator: s,
+			Validator: sr.validator,
 		},
 		Params: schema.Params{
 			"skip": schema.Param{

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -29,7 +29,7 @@ func TestResourceBind(t *testing.T) {
 				Validator: &schema.Connection{
 					Path:      ".bar",
 					Field:     "foo",
-					Validator: barSchema,
+					Validator: bar.validator,
 				},
 				Params: schema.Params{
 					"skip": schema.Param{

--- a/schema/query/projection_validator.go
+++ b/schema/query/projection_validator.go
@@ -34,8 +34,11 @@ func (pf ProjectionField) Validate(fg schema.FieldGetter) error {
 			if err := pf.Children.Validate(ref.SchemaValidator); err != nil {
 				return fmt.Errorf("%s.%v", pf.Name, err)
 			}
-		} else if _, ok := def.Validator.(*schema.Connection); ok {
+		} else if conn, ok := def.Validator.(*schema.Connection); ok {
 			// Sub-field on a sub resource (sub-request)
+			if err := pf.Children.Validate(conn.Validator); err != nil {
+				return fmt.Errorf("%s.%v", pf.Name, err)
+			}
 		} else if _, ok := def.Validator.(*schema.Dict); ok {
 			// Sub-field on a dict resource
 		} else if array, ok := def.Validator.(*schema.Array); ok {

--- a/schema/query/projection_validator_test.go
+++ b/schema/query/projection_validator_test.go
@@ -41,6 +41,16 @@ func TestProjectionValidate(t *testing.T) {
 					},
 				},
 			},
+			"connection": {
+				Validator: &schema.Connection{
+					Path:  "cnx",
+					Field: "ref",
+					Validator: schema.Schema{Fields: schema.Fields{
+						"id":   {},
+						"name": {},
+					}},
+				},
+			},
 		},
 	}
 	cases := []struct {
@@ -73,6 +83,9 @@ func TestProjectionValidate(t *testing.T) {
 		{`*,parent{*}`, nil},
 		{`*,parent{z:*}`, errors.New("parent.*: can't have an alias")},
 		{`*,parent{child{*}}`, errors.New("parent.child: field has no children")},
+		{`connection{name}`, nil},
+		{`connection{*}`, nil},
+		{`connection{foo}`, errors.New("connection.foo: unknown field")},
 	}
 	for i := range cases {
 		tc := cases[i]

--- a/schema/query/resolver.go
+++ b/schema/query/resolver.go
@@ -8,35 +8,36 @@ import (
 	"github.com/rs/rest-layer/schema"
 )
 
-type referenceResponseHandler func(payloads []map[string]interface{}, validator schema.Validator) error
+type referenceResponseHandler func(payloads []map[string]interface{}, validator schema.Validator, rsc Resource) error
 
 type referenceBatchResolver struct {
 	mu       sync.Mutex
 	requests []referenceRequest
+	rsc      Resource
 }
 
-func (rbr *referenceBatchResolver) request(resourcePath string, q *Query, handler referenceResponseHandler) {
+func (rbr *referenceBatchResolver) request(rsc Resource, q *Query, handler referenceResponseHandler) {
 	if len(q.Predicate) == 1 {
 		if eq, ok := q.Predicate[0].(*Equal); ok && eq.Field == "id" {
 			// Make an optimization for query on a single id so we can coalese them into a single request.
 			id := eq.Value
 			for _, r := range rbr.requests {
-				if r, ok := r.(*referenceMultiGetRequest); ok && r.resourcePath == resourcePath {
+				if r, ok := r.(*referenceMultiGetRequest); ok && rsc.Path() == r.rsc.Path() {
 					r.add(id, handler)
 					return
 				}
 			}
 			// Not found an existing multi get request for this path, create a new one.
-			r := &referenceMultiGetRequest{resourcePath: resourcePath}
+			r := &referenceMultiGetRequest{rsc: rsc}
 			r.add(id, handler)
 			rbr.appendRequest(r)
 			return
 		}
 	}
 	rbr.appendRequest(referenceSingleRequest{
-		resourcePath: resourcePath,
-		query:        q,
-		handler:      handler,
+		rsc:     rsc,
+		query:   q,
+		handler: handler,
 	})
 }
 
@@ -46,7 +47,7 @@ func (rbr *referenceBatchResolver) appendRequest(r referenceRequest) {
 	rbr.requests = append(rbr.requests, r)
 }
 
-func (rbr *referenceBatchResolver) execute(ctx context.Context, rsc Resource) error {
+func (rbr *referenceBatchResolver) execute(ctx context.Context) error {
 	for len(rbr.requests) > 0 {
 		// Get the list of requests.
 		requests := rbr.requests
@@ -59,7 +60,7 @@ func (rbr *referenceBatchResolver) execute(ctx context.Context, rsc Resource) er
 		for i := range requests {
 			r := requests[i]
 			go func() {
-				if e := r.execute(ctx, rsc); e != nil {
+				if e := r.execute(ctx); e != nil {
 					err = e
 				}
 				wg.Done()
@@ -75,31 +76,27 @@ func (rbr *referenceBatchResolver) execute(ctx context.Context, rsc Resource) er
 }
 
 type referenceRequest interface {
-	execute(ctx context.Context, rsc Resource) error
+	execute(ctx context.Context) error
 }
 
 type referenceSingleRequest struct {
-	resourcePath string
-	query        *Query
-	handler      referenceResponseHandler
+	rsc     Resource
+	query   *Query
+	handler referenceResponseHandler
 }
 
-func (r referenceSingleRequest) execute(ctx context.Context, rsc Resource) error {
-	subRsc, err := rsc.SubResource(ctx, r.resourcePath)
+func (r referenceSingleRequest) execute(ctx context.Context) error {
+	payloads, err := r.rsc.Find(ctx, r.query)
 	if err != nil {
 		return err
 	}
-	payloads, err := subRsc.Find(ctx, r.query)
-	if err != nil {
-		return err
-	}
-	return r.handler(payloads, subRsc.Validator())
+	return r.handler(payloads, r.rsc.Validator(), r.rsc)
 }
 
 type referenceMultiGetRequest struct {
-	resourcePath string
-	ids          []interface{}
-	handlers     []referenceResponseHandler
+	rsc      Resource
+	ids      []interface{}
+	handlers []referenceResponseHandler
 }
 
 func (r *referenceMultiGetRequest) add(id interface{}, handler referenceResponseHandler) {
@@ -107,29 +104,25 @@ func (r *referenceMultiGetRequest) add(id interface{}, handler referenceResponse
 	r.handlers = append(r.handlers, handler)
 }
 
-func (r *referenceMultiGetRequest) execute(ctx context.Context, rsc Resource) error {
-	subRsc, err := rsc.SubResource(ctx, r.resourcePath)
-	if err != nil {
-		return err
-	}
-	payloads, err := subRsc.MultiGet(ctx, r.ids)
+func (r *referenceMultiGetRequest) execute(ctx context.Context) error {
+	payloads, err := r.rsc.MultiGet(ctx, r.ids)
 	if err != nil {
 		return err
 	}
 	if len(payloads) != len(r.ids) {
 		return errors.New("invalid number of items returned by MultiGet")
 	}
-	validator := subRsc.Validator()
+	validator := r.rsc.Validator()
 	payloadsWrapper := make([]map[string]interface{}, 1)
 	for i, p := range payloads {
 		handler := r.handlers[i]
 		if p == nil {
-			if err := handler(payloadsWrapper[:0], validator); err != nil {
+			if err := handler(payloadsWrapper[:0], validator, r.rsc); err != nil {
 				return err
 			}
 		}
 		payloadsWrapper[0] = p
-		if err := handler(payloadsWrapper, validator); err != nil {
+		if err := handler(payloadsWrapper, validator, r.rsc); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
…eld projection for `Connected` resources.

This PR helps with following scenario:
- Having this resource graph
```
	index := resource.NewIndex()
	aa := index.Bind("a", a, mem.NewHandler(), resource.Conf{AllowedModes: resource.ReadWrite})
	bb := aa.Bind("b", "id", b, mem.NewHandler(), resource.Conf{AllowedModes: resource.ReadWrite})
	bb.Bind("c", "id", c, mem.NewHandler(), resource.Conf{AllowedModes: resource.ReadWrite})
```
Being able to correctly execute queries like `/a?fields=b{c}`