### PR TITLE
Fix for field validation on nested sub-resources

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -254,7 +254,9 @@ func (s Schema) validate(changes map[string]interface{}, base map[string]interfa
 	}
 	// Apply changes to the base in doc
 	for field, value := range base {
-		doc[field] = value
+		if _, found := s.Fields[field]; found {
+			doc[field] = value
+		}
 	}
 	for field, value := range changes {
 		if value == Tombstone {


### PR DESCRIPTION
After @Dragomir-Ivanov added nested sub-resources I found that is some issue when you have multiple sub-resources and schema references, for example:

```
user = schema.Schema{
  Fields: schema.Fields{
    "id": schema.IDField,
  },
}

ticket = schema.Schema{
  Fields: schema.Fields{
    "id": schema.IDField,
    "user": {
      Required:   true,
      Filterable: true,
      Validator: &schema.Reference{
        Path: "users",
      },
    },
  },
}

message = schema.Schema{
	Fields: schema.Fields{
		"id": schema.IDField,
		"ticket": {
			Required:   true,
			Filterable: true,
			Validator: &schema.Reference{
				Path: "users.tickets",
			},
		},
	},
}
```

http POST :8080/api/users/[user-id]/tickets/[ticker-id]/messages

Give you error:
```
{
    "code": 422,
    "issues": {
        "user": [
            "invalid field"
        ]
    },
    "message": "Document contains error(s)"
}
```

Because base is filled by user, and ticket id, in message you dont have user field so error occured. In this case we will check base field exists in resource fields. 
