### PR TITLE
Fix filtering on array containing an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,20 +919,46 @@ The same example with flags:
 However, keep in mind that Storers have to support regular expression and depending on the implementation of the storage handler the accepted syntax may vary.
 An error of `ErrNotImplemented` will be returned for those storage backends which do not support the `$regex` operator.
 
+The `$elemMatch` operator matches documents that contain an array field with at least one element that matches all the specified query criteria.
+```go
+			"telephones": schema.Field{
+				Filterable: true,
+				Validator: &schema.Array{
+					Values: schema.Field{
+						Validator:  &schema.Object{Schema: &Telephone},
+					},
+				},
+			},
+```
+
+Matching documents that contain specific values within array objects can be done with `$elemMatch`:
+```js
+{telephones: {$elemMatch: {name: "John Snow", active: true}}}
+```
+The snippet above will return all documents, which `telephones` array field contains objects that have `name` **_AND_** `active` fields matching queried values.
+> Note that documents returned may contain other objects in `telephones` that don't match the query above, but at least one object will do. Further filtering could be needed on the API client side.
+
+#### *$elemMatch* Limitation
+`$elemMatch` will work only for arrays of objects for now. Later it could be extended to work on plain arrays e.g:
+```js
+{numbers: {$elemMatch: {$gt: 20}}}
+```
+
 #### Filter operators
 
-| Operator  | Usage                           | Description
-| --------- | ------------------------------- | ------------
-| `$or`     | `{$or: [{a: "b"}, {a: "c"}]}`   | Join two clauses with a logical `OR` conjunction.
-| `$and`    | `{$and: [{a: "b"}, {b: "c"}]}`  | Join two clauses with a logical `AND` conjunction.
-| `$in`     | `{a: {$in: ["b", "c"]}}`        | Match a field against several values.
-| `$nin`    | `{a: {$nin: ["b", "c"]}}`       | Opposite of `$in`.
-| `$lt`     | `{a: {$lt: 10}}`                | Fields value is lower than specified number.
-| `$lte`    | `{a: {$lte: 10}}`               | Fields value is lower than or equal to the specified number.
-| `$gt`     | `{a: {$gt: 10}}`                | Fields value is greater than specified number.
-| `$gte`    | `{a: {$gte: 10}}`               | Fields value is greater than or equal to the specified number.
-| `$exists` | `{a: {$exists: true}}`          | Match if the field is present (or not if set to `false`) in the item, event if `nil`.
-| `$regex`  | `{a: {$regex: "fo[o]{1}"}}`     | Match regular expression on a field's value.
+| Operator     | Usage                           | Description
+| -------------| --------------------------------| ------------
+| `$or`        | `{$or: [{a: "b"}, {a: "c"}]}`   | Join two clauses with a logical `OR` conjunction.
+| `$and`       | `{$and: [{a: "b"}, {b: "c"}]}`  | Join two clauses with a logical `AND` conjunction.
+| `$in`        | `{a: {$in: ["b", "c"]}}`        | Match a field against several values.
+| `$nin`       | `{a: {$nin: ["b", "c"]}}`       | Opposite of `$in`.
+| `$lt`        | `{a: {$lt: 10}}`                | Fields value is lower than specified number.
+| `$lte`       | `{a: {$lte: 10}}`               | Fields value is lower than or equal to the specified number.
+| `$gt`        | `{a: {$gt: 10}}`                | Fields value is greater than specified number.
+| `$gte`       | `{a: {$gte: 10}}`               | Fields value is greater than or equal to the specified number.
+| `$exists`    | `{a: {$exists: true}}`          | Match if the field is present (or not if set to `false`) in the item, event if `nil`.
+| `$regex`     | `{a: {$regex: "fo[o]{1}"}}`     | Match regular expression on a field's value.
+| `$elemMatch` | `{a: {$elemMatch: {b: "foo"}}}` | Match array items against multiple query criteria.
 
 *Some storage handlers may not support all operators. Refer to the storage handler's documentation for more info.*
 

--- a/schema/array.go
+++ b/schema/array.go
@@ -50,13 +50,18 @@ func (v Array) validateValues(values []interface{}, query bool) ([]interface{}, 
 
 // ValidateQuery implements FieldQueryValidator.
 func (v Array) ValidateQuery(value interface{}) (interface{}, error) {
-	values, ok := value.([]interface{})
-	if !ok {
-		return nil, errors.New("not an array")
+	values, isArray := value.([]interface{})
+	if !isArray {
+		values = append(values, value)
 	}
+
 	arr, err := v.validateValues(values, true)
 	if err != nil {
 		return nil, err
+	}
+
+	if !isArray {
+		return arr[0], nil
 	}
 	return arr, nil
 }

--- a/schema/array.go
+++ b/schema/array.go
@@ -18,12 +18,7 @@ type Array struct {
 
 // Compile implements the ReferenceCompiler interface.
 func (v *Array) Compile(rc ReferenceChecker) (err error) {
-	if c, ok := v.Values.Validator.(Compiler); ok {
-		if err = c.Compile(rc); err != nil {
-			return
-		}
-	}
-	return
+	return v.Values.Compile(rc)
 }
 
 func (v Array) validateValues(values []interface{}, query bool) ([]interface{}, error) {

--- a/schema/array_test.go
+++ b/schema/array_test.go
@@ -119,7 +119,7 @@ func TestArrayQueryValidator(t *testing.T) {
 			Name:      `Values.Validator=&String{},ValidateQuery("value")`,
 			Validator: &schema.Array{Values: schema.Field{Validator: &schema.String{}}},
 			Input:     "value",
-			Error:     "not an array",
+			Expect:    "value",
 		},
 		{
 			Name:      `MinLen=2,ValidateQuery([]interface{}{true,false})`,

--- a/schema/array_test.go
+++ b/schema/array_test.go
@@ -19,7 +19,13 @@ func TestArrayValidatorCompile(t *testing.T) {
 			Name:             "Values.Validator=&String{Regexp:invalid}",
 			Compiler:         &schema.Array{Values: schema.Field{Validator: &schema.String{Regexp: "[invalid re"}}},
 			ReferenceChecker: fakeReferenceChecker{},
-			Error:            "invalid regexp: error parsing regexp: missing closing ]: `[invalid re`",
+			Error:            ": invalid regexp: error parsing regexp: missing closing ]: `[invalid re`",
+		},
+		{
+			Name:             "Values.Validator=String{}",
+			Compiler:         &schema.Array{Values: schema.Field{Validator: schema.String{}}},
+			ReferenceChecker: fakeReferenceChecker{},
+			Error:            ": not a schema.Validator pointer",
 		},
 	}
 	for i := range testCases {

--- a/schema/query/predicate_parser.go
+++ b/schema/query/predicate_parser.go
@@ -106,7 +106,7 @@ func (p *predicateParser) parseExpression() (Expression, error) {
 		}
 		or := Or(subExp)
 		return &or, nil
-	case opExists, opIn, opNotIn, opNotEqual, opRegex,
+	case opExists, opIn, opNotIn, opNotEqual, opRegex, opElemMatch,
 		opLowerThan, opLowerOrEqual, opGreaterThan, opGreaterOrEqual:
 		p.pos = oldPos
 		return nil, fmt.Errorf("%s: invalid placement", label)
@@ -248,6 +248,16 @@ func (p *predicateParser) parseCommand(field string) (Expression, error) {
 				return nil, fmt.Errorf("%s: expected '}' got %q", label, p.peek())
 			}
 			return &Regex{Field: field, Value: re}, nil
+		case opElemMatch:
+			exps, err := p.parseExpressions()
+			if err != nil {
+				return nil, fmt.Errorf("%s: %v", label, err)
+			}
+			p.eatWhitespaces()
+			if !p.expect('}') {
+				return nil, fmt.Errorf("%s: expected '}' got %q", label, p.peek())
+			}
+			return &ElemMatch{Field: field, Exps: exps}, nil
 		}
 	}
 VALUE:

--- a/schema/query/predicate_parser_test.go
+++ b/schema/query/predicate_parser_test.go
@@ -134,6 +134,11 @@ func TestParse(t *testing.T) {
 			nil,
 		},
 		{
+			`{"foo": {"$elemMatch": {"bar": "one", "baz": "two"}}}`,
+			Predicate{&ElemMatch{Field: "foo", Exps: []Expression{&Equal{Field: "bar", Value: "one"}, &Equal{Field: "baz", Value: "two"}}}},
+			nil,
+		},
+		{
 			`{`,
 			Predicate{},
 			errors.New("char 1: expected a label got '\\x00'"),
@@ -320,6 +325,21 @@ func TestParse(t *testing.T) {
 			Predicate{},
 			errors.New("char 28: foo: $regex: invalid regex: error parsing regexp: invalid or unsupported Perl syntax: `(?=`"),
 		},
+		{
+			`{"foo": {"$elemMatch": "two"}}`,
+			Predicate{},
+			errors.New("char 23: foo: $elemMatch: expected '{' got '\"'"),
+		},
+		{
+			`{"foo": {"$elemMatch": [{"bar": "one", "baz": "two"}]}}`,
+			Predicate{},
+			errors.New("char 23: foo: $elemMatch: expected '{' got '['"),
+		},
+		{
+			`{"foo": {"$elemMatch": null}}`,
+			Predicate{},
+			errors.New("char 23: foo: $elemMatch: expected '{' got 'n'"),
+		},
 		// Hierarchy issues
 		{
 			`{"$ne": "bar"}`,
@@ -345,6 +365,11 @@ func TestParse(t *testing.T) {
 			`{"$regex": "someregexpression"}`,
 			Predicate{},
 			errors.New("char 1: $regex: invalid placement"),
+		},
+		{
+			`{"$elemMatch": "someregexpression"}`,
+			Predicate{},
+			errors.New("char 1: $elemMatch: invalid placement"),
 		},
 	}
 	for i := range tests {

--- a/schema/query/predicate_test.go
+++ b/schema/query/predicate_test.go
@@ -181,6 +181,19 @@ func TestMatch(t *testing.T) {
 			},
 			nil,
 		},
+
+		{
+			`{"foo": {$elemMatch: {a: "bar",b: "baz"}}}`, []test{
+				{map[string]interface{}{"foo": []interface{}{map[string]interface{}{"a": "bar"}}}, false},
+				{map[string]interface{}{"foo": []interface{}{map[string]interface{}{"a": "bar", "b": "baz"}}}, true},
+				{map[string]interface{}{"foo": []interface{}{map[string]interface{}{"a": "bar", "b": "baz"}, map[string]interface{}{"c": "bar", "d": "baz"}}}, true},
+				{map[string]interface{}{"foo": []interface{}{map[string]interface{}{"a": "bar", "b": "baz1"}}}, false},
+				{map[string]interface{}{"foo": []interface{}{map[string]interface{}{"a": "bar", "c": "baz1"}}}, false},
+				{map[string]interface{}{"foo": []interface{}{map[string]interface{}{}}}, false},
+				{map[string]interface{}{"foo": []interface{}{}}, false},
+			},
+			nil,
+		},
 	}
 	for i := range tests {
 		tt := tests[i]
@@ -226,6 +239,7 @@ func TestString(t *testing.T) {
 		`{"foo": "bar", "$or": [{"bar": "baz"}, {"bar": "foo"}]}`: `{foo: "bar", $or: [{bar: "baz"}, {bar: "foo"}]}`,
 		`{"foo": ["bar", "baz"]}`:                                 `{foo: ["bar","baz"]}`,
 		`{"foo.bar": "baz"}`:                                      `{foo.bar: "baz"}`,
+		`{"foo":{"$elemMatch":{"a":"bar","b":"baz"}}}`:            `{foo: {$elemMatch: {a: "bar", b: "baz"}}}`,
 	}
 	for query, want := range tests {
 		q, err := ParsePredicate(query)


### PR DESCRIPTION
This patch allows using `filter={field.subfield:"foo"}` or
`filter={field.subfield:{$regex:"^foo"}}` where `field` is an array
containing an object, and `subfield` is object field.

Also make `rest-layer-mem` match Mongo behaviour in this usecase.