### PR TITLE
Fix field hook for HTTP PUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Below is an overview over recent breaking changes, starting from an arbitrary po
   - `filter` parameters will be validated for type match only, instead of type & constrains.
 - PR #228: `Reference` projection fields will be validated against referenced resource schema.
 - PR #230: `Connection` projection fields will be validated against connected resource schema.
+- PR #241: Always call `OnUpdate` field hook on HTTP PUT for existing documents.
 
 From the next release and onwards (0.2), this list will summarize breaking changes done to master since the last release.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Below is an overview over recent breaking changes, starting from an arbitrary po
   - `filter` parameters will be validated for type match only, instead of type & constrains.
 - PR #228: `Reference` projection fields will be validated against referenced resource schema.
 - PR #230: `Connection` projection fields will be validated against connected resource schema.
-- PR #241: Always call `OnUpdate` field hook on HTTP PUT for existing documents.
+- PR #241: Always call `OnUpdate` field hook on HTTP PUT for existing documents. Deleting a field with `Default` value set, will always be reset to its default value.
 
 From the next release and onwards (0.2), this list will summarize breaking changes done to master since the last release.
 
@@ -1252,7 +1252,9 @@ Used to query a resource with its sub/embedded resources.
 Used to create new resource document, where new `ID` is generated from the server.
 
 ### PUT
-Used to create/update single resource document given its `ID`. Be aware when dealing with resource fields with `Default` set. Initial creation for such resources will set particular field to its default value if omitted, however on subsequent `PUT` calls this field will be deleted if omitted. If persistent `Default` field is needed use `{Required: true}` with it. 
+Used to create/update single resource document given its `ID`. On initial request, `onInsert` resource hook will be called. All subsequent `PUT` requests will call `onUpdate` resource hook.
+
+Be aware when dealing with resource fields with `Default` set. If missing from payload or deleted, such fields will be reset to their `default value`.
 
 ### PATCH
 Used to update/patch single resource document given its `ID`. REST Layer supports following update protocols:

--- a/rest/method_item_put_test.go
+++ b/rest/method_item_put_test.go
@@ -388,8 +388,8 @@ func TestPutItemDefault(t *testing.T) {
 				return http.NewRequest("PUT", "/foo/2", body)
 			},
 			ResponseCode: http.StatusOK,
-			ResponseBody: `{"id": "2", "foo": "baz"}`,
-			ExtraTest:    checkPayload("foo", "2", map[string]interface{}{"id": "2", "foo": "baz"}),
+			ResponseBody: `{"id": "2", "foo": "baz", "bar": "default"}`,
+			ExtraTest:    checkPayload("foo", "2", map[string]interface{}{"id": "2", "foo": "baz", "bar": "default"}),
 		},
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -188,7 +188,7 @@ func (s Schema) Prepare(ctx context.Context, payload map[string]interface{}, ori
 		// Call the OnInit or OnUpdate depending on the presence of the original doc and the
 		// state of the replace argument.
 		var hook func(ctx context.Context, value interface{}) interface{}
-		if original == nil || replace {
+		if original == nil {
 			hook = def.OnInit
 		} else {
 			hook = def.OnUpdate

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -142,7 +142,7 @@ func (s Schema) Prepare(ctx context.Context, payload map[string]interface{}, ori
 				// previous value as the client would have no way to resubmit the stored value.
 				if def.Hidden && !def.ReadOnly {
 					changes[field] = oValue
-				} else if def.Required && def.Default != nil {
+				} else if def.Default != nil {
 					changes[field] = def.Default
 				} else {
 					changes[field] = Tombstone


### PR DESCRIPTION
Always calls `OnUpdate` field hook on HTTP PUT for existing documents.