### PR TITLE
implement '$not' regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,8 @@ The same example with flags:
 However, keep in mind that Storers have to support regular expression and depending on the implementation of the storage handler the accepted syntax may vary.
 An error of `ErrNotImplemented` will be returned for those storage back-ends which do not support the `$regex` operator.
 
+The operator `$not` functions as an opposite operator to `$regex`. Unlike MongoDB, we do not allow `$not` as a general negation operator.
+
 The `$elemMatch` operator matches documents that contain an array field with at least one element that matches all the specified query criteria.
 ```go
 			"telephones": schema.Field{
@@ -1041,6 +1043,7 @@ The snippet above will return all documents, which `telephones` array field cont
 | `$gte`       | `{a: {$gte: 10}}`               | Fields value is greater than or equal to the specified number.
 | `$exists`    | `{a: {$exists: true}}`          | Match if the field is present (or not if set to `false`) in the item, event if `nil`.
 | `$regex`     | `{a: {$regex: "fo[o]{1}"}}`     | Match regular expression on a field's value.
+| `$not`       | `{a: {$not: "fo[o]{1}"}}`       | Opposite of `$regex`.
 | `$elemMatch` | `{a: {$elemMatch: {b: "foo"}}}` | Match array items against multiple query criteria.
 
 *Some storage handlers may not support all operators. Refer to the storage handler's documentation for more info.*

--- a/schema/query/predicate_parser.go
+++ b/schema/query/predicate_parser.go
@@ -107,7 +107,7 @@ func (p *predicateParser) parseExpression() (Expression, error) {
 		or := Or(subExp)
 		return &or, nil
 	case opExists, opIn, opNotIn, opNotEqual, opRegex, opElemMatch,
-		opLowerThan, opLowerOrEqual, opGreaterThan, opGreaterOrEqual:
+		opLowerThan, opLowerOrEqual, opGreaterThan, opGreaterOrEqual, opNot:
 		p.pos = oldPos
 		return nil, fmt.Errorf("%s: invalid placement", label)
 	default:
@@ -234,7 +234,7 @@ func (p *predicateParser) parseCommand(field string) (Expression, error) {
 			case opGreaterOrEqual:
 				return &GreaterOrEqual{Field: field, Value: value}, nil
 			}
-		case opRegex:
+		case opRegex, opNot:
 			str, err := p.parseString()
 			if err != nil {
 				return nil, fmt.Errorf("%s: %v", label, err)
@@ -247,7 +247,8 @@ func (p *predicateParser) parseCommand(field string) (Expression, error) {
 			if !p.expect('}') {
 				return nil, fmt.Errorf("%s: expected '}' got %q", label, p.peek())
 			}
-			return &Regex{Field: field, Value: re}, nil
+			negated := label == opNot
+			return &Regex{Field: field, Value: re, Negated: negated}, nil
 		case opElemMatch:
 			exps, err := p.parseExpressions()
 			if err != nil {

--- a/schema/query/predicate_parser_test.go
+++ b/schema/query/predicate_parser_test.go
@@ -104,6 +104,11 @@ func TestParse(t *testing.T) {
 			nil,
 		},
 		{
+			`{"foo": {"$not": "regex.+awesome"}}`,
+			Predicate{&Regex{Field: "foo", Value: regexp.MustCompile("regex.+awesome"), Negated: true}},
+			nil,
+		},
+		{
 			`{"$and": [{"foo": "bar"}, {"foo": "baz"}]}`,
 			Predicate{&And{&Equal{Field: "foo", Value: "bar"}, &Equal{Field: "foo", Value: "baz"}}},
 			nil,
@@ -360,6 +365,11 @@ func TestParse(t *testing.T) {
 			`{"$elemMatch": "someregexpression"}`,
 			Predicate{},
 			errors.New("char 1: $elemMatch: invalid placement"),
+		},
+		{
+			`{"$not": "someregexpression"}`,
+			Predicate{},
+			errors.New("char 1: $not: invalid placement"),
 		},
 	}
 	for i := range tests {

--- a/schema/query/predicate_test.go
+++ b/schema/query/predicate_test.go
@@ -141,8 +141,20 @@ func TestMatch(t *testing.T) {
 			nil,
 		},
 		{
+			`{"foo": {"$not": "rege[x]{1}.+some"}}`, []test{
+				{map[string]interface{}{"foo": "regex-is-awesome"}, false},
+			},
+			nil,
+		},
+		{
 			`{"foo": {"$regex": "^(?i)my.+-rest.+$"}}`, []test{
 				{map[string]interface{}{"foo": "myAwesome-RESTApplication"}, true},
+			},
+			nil,
+		},
+		{
+			`{"foo": {"$not": "^(?i)my.+-rest.+$"}}`, []test{
+				{map[string]interface{}{"foo": "myAwesome-RESTApplication"}, false},
 			},
 			nil,
 		},


### PR DESCRIPTION
Implementing `$not` filter operator with regex. It has the opposite function of `$regex`.

Part of #273 